### PR TITLE
feat: Add analysis_cache resource support and ALM settings builders

### DIFF
--- a/src/core/builders/BaseBuilder.ts
+++ b/src/core/builders/BaseBuilder.ts
@@ -1,0 +1,29 @@
+/**
+ * Base builder class for all API builders
+ */
+export abstract class BaseBuilder<TRequest, TResponse = void> {
+  protected params: Partial<TRequest> = {};
+
+  constructor(protected executor: (params: TRequest) => Promise<TResponse>) {}
+
+  /**
+   * Set a parameter value
+   */
+  protected setParam<K extends keyof TRequest>(key: K, value: TRequest[K]): this {
+    this.params[key] = value;
+    return this;
+  }
+
+  /**
+   * Set multiple parameters at once
+   */
+  protected setParams(params: Partial<TRequest>): this {
+    Object.assign(this.params, params);
+    return this;
+  }
+
+  /**
+   * Execute the operation
+   */
+  abstract execute(): Promise<TResponse>;
+}

--- a/src/core/builders/PaginatedBuilder.ts
+++ b/src/core/builders/PaginatedBuilder.ts
@@ -1,0 +1,86 @@
+import { BaseBuilder } from './BaseBuilder';
+
+/**
+ * Common interface for paginated requests
+ */
+export interface PaginatedRequest {
+  p?: number; // page number
+  ps?: number; // page size
+}
+
+/**
+ * Common interface for paginated responses
+ */
+export interface PaginatedResponse {
+  paging?: {
+    pageIndex: number;
+    pageSize: number;
+    total: number;
+  };
+  isLastPage?: boolean;
+}
+
+/**
+ * Base builder for paginated search operations
+ */
+export abstract class PaginatedBuilder<
+  TRequest extends PaginatedRequest,
+  TResponse extends PaginatedResponse,
+  TItem,
+> extends BaseBuilder<TRequest, TResponse> {
+  /**
+   * Set the page number
+   */
+  page(pageNumber: number): this {
+    return this.setParam('p' as keyof TRequest, pageNumber as TRequest[keyof TRequest]);
+  }
+
+  /**
+   * Set the page size
+   */
+  pageSize(size: number): this {
+    return this.setParam('ps' as keyof TRequest, size as TRequest[keyof TRequest]);
+  }
+
+  /**
+   * Execute and return all items using async iteration
+   */
+  async *all(): AsyncGenerator<TItem> {
+    let currentPage = 1;
+    let hasMore = true;
+
+    while (hasMore) {
+      const response = await this.page(currentPage).execute();
+      const items = this.getItems(response);
+
+      for (const item of items) {
+        yield item;
+      }
+
+      hasMore = this.hasMorePages(response, currentPage);
+      currentPage++;
+    }
+  }
+
+  /**
+   * Check if there are more pages
+   */
+  protected hasMorePages(response: TResponse, currentPage: number): boolean {
+    // Handle different pagination formats
+    if (response.paging) {
+      const totalPages = Math.ceil(response.paging.total / response.paging.pageSize);
+      return currentPage < totalPages;
+    }
+
+    if ('isLastPage' in response) {
+      return !response.isLastPage;
+    }
+
+    return false;
+  }
+
+  /**
+   * Get the items from the response
+   */
+  protected abstract getItems(response: TResponse): TItem[];
+}

--- a/src/core/builders/index.ts
+++ b/src/core/builders/index.ts
@@ -1,0 +1,4 @@
+export { BaseBuilder } from './BaseBuilder';
+export { PaginatedBuilder } from './PaginatedBuilder';
+export type { PaginatedRequest, PaginatedResponse } from './PaginatedBuilder';
+export { isRequired, validateRequired, validateOAuth } from './validation';

--- a/src/core/builders/validation.ts
+++ b/src/core/builders/validation.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared validation utilities for builders
+ */
+
+/**
+ * Check if a value is a non-empty string
+ */
+export function isRequired(value: unknown): value is string {
+  return typeof value === 'string' && value !== '';
+}
+
+/**
+ * Validate that a field is required (non-empty string)
+ * @throws Error if validation fails
+ */
+export function validateRequired(value: unknown, fieldName: string): void {
+  if (!isRequired(value)) {
+    throw new Error(`${fieldName} is required`);
+  }
+}
+
+/**
+ * Validate OAuth credentials
+ * @throws Error if validation fails
+ */
+export function validateOAuth(
+  clientId: unknown,
+  clientSecret: unknown,
+  providerName = 'OAuth'
+): void {
+  if (!isRequired(clientId) || !isRequired(clientSecret)) {
+    throw new Error(`${providerName} client ID and secret are required`);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { AlmIntegrationsClient } from './resources/alm-integrations';
 import { AlmSettingsClient } from './resources/alm-settings';
+import { AnalysisCacheClient } from './resources/analysis-cache';
 
 interface ProjectsResponse {
   [key: string]: unknown;
@@ -18,6 +19,7 @@ export class SonarQubeClient {
   // Resource clients
   public readonly almIntegrations: AlmIntegrationsClient;
   public readonly almSettings: AlmSettingsClient;
+  public readonly analysisCache: AnalysisCacheClient;
 
   private readonly baseUrl: string;
   private readonly token: string | undefined;
@@ -29,6 +31,7 @@ export class SonarQubeClient {
     // Initialize resource clients
     this.almIntegrations = new AlmIntegrationsClient(this.baseUrl, this.token);
     this.almSettings = new AlmSettingsClient(this.baseUrl, this.token);
+    this.analysisCache = new AnalysisCacheClient(this.baseUrl, this.token);
   }
 
   // Legacy methods for backward compatibility
@@ -126,3 +129,9 @@ export type {
   // Validation types
   AlmSettingValidationError,
 } from './resources/alm-settings/types';
+
+// Re-export types from analysis cache
+export type {
+  GetAnalysisCacheRequest,
+  GetAnalysisCacheResponse,
+} from './resources/analysis-cache/types';

--- a/src/resources/alm-settings/AlmSettingsClient.ts
+++ b/src/resources/alm-settings/AlmSettingsClient.ts
@@ -27,6 +27,17 @@ import type {
   ValidateAlmSettingRequest,
   ValidateAlmSettingResponse,
 } from './types';
+import {
+  CreateGitHubBuilder,
+  UpdateGitHubBuilder,
+  CreateBitbucketCloudBuilder,
+  UpdateBitbucketCloudBuilder,
+  SetAzureBindingBuilder,
+  SetBitbucketBindingBuilder,
+  SetBitbucketCloudBindingBuilder,
+  SetGitHubBindingBuilder,
+  SetGitLabBindingBuilder,
+} from './builders';
 
 /**
  * Client for managing DevOps Platform Settings (ALM Settings)
@@ -294,5 +305,122 @@ export class AlmSettingsClient extends BaseClient {
       key: params.key,
     });
     return this.request(`/api/alm_settings/validate?${query.toString()}`);
+  }
+
+  // Builder methods
+
+  /**
+   * Create a builder for creating GitHub ALM settings
+   * @param key The unique key for the ALM setting
+   * @returns A builder for creating GitHub settings
+   */
+  createGitHubBuilder(key: string): CreateGitHubBuilder {
+    return new CreateGitHubBuilder(async (params) => this.createGitHub(params), key);
+  }
+
+  /**
+   * Create a builder for updating GitHub ALM settings
+   * @param key The key of the ALM setting to update
+   * @returns A builder for updating GitHub settings
+   */
+  updateGitHubBuilder(key: string): UpdateGitHubBuilder {
+    return new UpdateGitHubBuilder(async (params) => this.updateGitHub(params), key);
+  }
+
+  /**
+   * Create a builder for creating Bitbucket Cloud ALM settings
+   * @param key The unique key for the ALM setting
+   * @returns A builder for creating Bitbucket Cloud settings
+   */
+  createBitbucketCloudBuilder(key: string): CreateBitbucketCloudBuilder {
+    return new CreateBitbucketCloudBuilder(
+      async (params) => this.createBitbucketCloud(params),
+      key
+    );
+  }
+
+  /**
+   * Create a builder for updating Bitbucket Cloud ALM settings
+   * @param key The key of the ALM setting to update
+   * @returns A builder for updating Bitbucket Cloud settings
+   */
+  updateBitbucketCloudBuilder(key: string): UpdateBitbucketCloudBuilder {
+    return new UpdateBitbucketCloudBuilder(
+      async (params) => this.updateBitbucketCloud(params),
+      key
+    );
+  }
+
+  /**
+   * Create a builder for setting Azure DevOps project bindings
+   * @param project The project key
+   * @param almSetting The ALM setting key
+   * @returns A builder for setting Azure bindings
+   */
+  setAzureBindingBuilder(project: string, almSetting: string): SetAzureBindingBuilder {
+    return new SetAzureBindingBuilder(
+      async (params) => this.setAzureBinding(params),
+      project,
+      almSetting
+    );
+  }
+
+  /**
+   * Create a builder for setting Bitbucket Server project bindings
+   * @param project The project key
+   * @param almSetting The ALM setting key
+   * @returns A builder for setting Bitbucket bindings
+   */
+  setBitbucketBindingBuilder(project: string, almSetting: string): SetBitbucketBindingBuilder {
+    return new SetBitbucketBindingBuilder(
+      async (params) => this.setBitbucketBinding(params),
+      project,
+      almSetting
+    );
+  }
+
+  /**
+   * Create a builder for setting Bitbucket Cloud project bindings
+   * @param project The project key
+   * @param almSetting The ALM setting key
+   * @returns A builder for setting Bitbucket Cloud bindings
+   */
+  setBitbucketCloudBindingBuilder(
+    project: string,
+    almSetting: string
+  ): SetBitbucketCloudBindingBuilder {
+    return new SetBitbucketCloudBindingBuilder(
+      async (params) => this.setBitbucketCloudBinding(params),
+      project,
+      almSetting
+    );
+  }
+
+  /**
+   * Create a builder for setting GitHub project bindings
+   * @param project The project key
+   * @param almSetting The ALM setting key
+   * @returns A builder for setting GitHub bindings
+   */
+  setGitHubBindingBuilder(project: string, almSetting: string): SetGitHubBindingBuilder {
+    return new SetGitHubBindingBuilder(
+      async (params) => this.setGitHubBinding(params),
+      project,
+      almSetting
+    );
+  }
+
+  /**
+   * Create a builder for setting GitLab project bindings
+   * @param project The project key
+   * @param almSetting The ALM setting key
+   * @returns A builder for setting GitLab bindings
+   */
+  setGitLabBindingBuilder(project: string, almSetting: string): SetGitLabBindingBuilder {
+    return new SetGitLabBindingBuilder(
+      async (params) => this.setGitLabBinding(params),
+      project,
+      almSetting
+    );
   }
 }

--- a/src/resources/alm-settings/__tests__/builders.test.ts
+++ b/src/resources/alm-settings/__tests__/builders.test.ts
@@ -1,0 +1,331 @@
+import { AlmSettingsClient } from '../AlmSettingsClient';
+
+describe('AlmSettings Builders', () => {
+  let client: AlmSettingsClient;
+  const baseUrl = 'https://sonarqube.example.com';
+  const token = 'test-token';
+
+  beforeEach(() => {
+    client = new AlmSettingsClient(baseUrl, token);
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('GitHub Builders', () => {
+    describe('createGitHubBuilder', () => {
+      it('should create GitHub ALM setting with all parameters', async () => {
+        const mockResponse = { ok: true, text: jest.fn().mockResolvedValue('') };
+        (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+        await client
+          .createGitHubBuilder('github-key')
+          .withAppId('app-123')
+          .withOAuth('client-id', 'client-secret')
+          .withPrivateKey('private-key')
+          .withUrl('https://github.enterprise.com')
+          .withWebhookSecret('webhook-secret')
+          .execute();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'https://sonarqube.example.com/api/alm_settings/create_github',
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: 'Bearer test-token',
+            },
+            body: JSON.stringify({
+              key: 'github-key',
+              appId: 'app-123',
+              clientId: 'client-id',
+              clientSecret: 'client-secret',
+              privateKey: 'private-key',
+              url: 'https://github.enterprise.com',
+              webhookSecret: 'webhook-secret',
+            }),
+          }
+        );
+      });
+
+      it('should throw error when required fields are missing', async () => {
+        const builder = client.createGitHubBuilder('github-key');
+
+        await expect(builder.execute()).rejects.toThrow('GitHub App ID is required');
+
+        builder.withAppId('app-123');
+        await expect(builder.execute()).rejects.toThrow('OAuth client ID and secret are required');
+
+        builder.withOAuth('client-id', 'client-secret');
+        await expect(builder.execute()).rejects.toThrow('Private key is required');
+
+        builder.withPrivateKey('private-key');
+        await expect(builder.execute()).rejects.toThrow('URL is required');
+      });
+    });
+
+    describe('updateGitHubBuilder', () => {
+      it('should update GitHub ALM setting with partial parameters', async () => {
+        const mockResponse = { ok: true, text: jest.fn().mockResolvedValue('') };
+        (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+        await client
+          .updateGitHubBuilder('github-key')
+          .withNewKey('new-github-key')
+          .withAppId('new-app-123')
+          .withWebhookSecret('new-webhook-secret')
+          .execute();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'https://sonarqube.example.com/api/alm_settings/update_github',
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: 'Bearer test-token',
+            },
+            body: JSON.stringify({
+              key: 'github-key',
+              newKey: 'new-github-key',
+              appId: 'new-app-123',
+              webhookSecret: 'new-webhook-secret',
+            }),
+          }
+        );
+      });
+    });
+  });
+
+  describe('Bitbucket Cloud Builders', () => {
+    describe('createBitbucketCloudBuilder', () => {
+      it('should create Bitbucket Cloud ALM setting', async () => {
+        const mockResponse = { ok: true, text: jest.fn().mockResolvedValue('') };
+        (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+        await client
+          .createBitbucketCloudBuilder('bitbucket-cloud-key')
+          .withOAuth('consumer-key', 'consumer-secret')
+          .withWorkspace('my-workspace')
+          .execute();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'https://sonarqube.example.com/api/alm_settings/create_bitbucketcloud',
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: 'Bearer test-token',
+            },
+            body: JSON.stringify({
+              key: 'bitbucket-cloud-key',
+              clientId: 'consumer-key',
+              clientSecret: 'consumer-secret',
+              workspace: 'my-workspace',
+            }),
+          }
+        );
+      });
+
+      it('should throw error when required fields are missing', async () => {
+        const builder = client.createBitbucketCloudBuilder('bitbucket-cloud-key');
+
+        await expect(builder.execute()).rejects.toThrow(
+          'OAuth consumer key and secret are required'
+        );
+
+        builder.withOAuth('consumer-key', 'consumer-secret');
+        await expect(builder.execute()).rejects.toThrow('Workspace is required');
+      });
+    });
+
+    describe('updateBitbucketCloudBuilder', () => {
+      it('should update Bitbucket Cloud ALM setting', async () => {
+        const mockResponse = { ok: true, text: jest.fn().mockResolvedValue('') };
+        (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+        await client
+          .updateBitbucketCloudBuilder('bitbucket-cloud-key')
+          .withWorkspace('new-workspace')
+          .execute();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'https://sonarqube.example.com/api/alm_settings/update_bitbucketcloud',
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: 'Bearer test-token',
+            },
+            body: JSON.stringify({
+              key: 'bitbucket-cloud-key',
+              workspace: 'new-workspace',
+            }),
+          }
+        );
+      });
+    });
+  });
+
+  describe('Binding Builders', () => {
+    describe('setAzureBindingBuilder', () => {
+      it('should set Azure binding', async () => {
+        const mockResponse = { ok: true, text: jest.fn().mockResolvedValue('') };
+        (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+        await client
+          .setAzureBindingBuilder('my-project', 'azure-setting-1')
+          .withProjectName('AzureProject')
+          .withRepository('my-repo')
+          .asMonorepo()
+          .execute();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'https://sonarqube.example.com/api/alm_settings/set_azure_binding',
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: 'Bearer test-token',
+            },
+            body: JSON.stringify({
+              project: 'my-project',
+              almSetting: 'azure-setting-1',
+              projectName: 'AzureProject',
+              repositoryName: 'my-repo',
+              monorepo: true,
+            }),
+          }
+        );
+      });
+
+      it('should throw error when required fields are missing', async () => {
+        const builder = client.setAzureBindingBuilder('my-project', 'azure-setting-1');
+
+        await expect(builder.execute()).rejects.toThrow('Azure project name is required');
+
+        builder.withProjectName('AzureProject');
+        await expect(builder.execute()).rejects.toThrow('Repository name is required');
+      });
+    });
+
+    describe('setBitbucketBindingBuilder', () => {
+      it('should set Bitbucket binding', async () => {
+        const mockResponse = { ok: true, text: jest.fn().mockResolvedValue('') };
+        (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+        await client
+          .setBitbucketBindingBuilder('my-project', 'bitbucket-setting-1')
+          .withRepository('my-repo')
+          .withSlug('repo-slug')
+          .execute();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'https://sonarqube.example.com/api/alm_settings/set_bitbucket_binding',
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: 'Bearer test-token',
+            },
+            body: JSON.stringify({
+              project: 'my-project',
+              almSetting: 'bitbucket-setting-1',
+              repository: 'my-repo',
+              slug: 'repo-slug',
+            }),
+          }
+        );
+      });
+    });
+
+    describe('setBitbucketCloudBindingBuilder', () => {
+      it('should set Bitbucket Cloud binding', async () => {
+        const mockResponse = { ok: true, text: jest.fn().mockResolvedValue('') };
+        (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+        await client
+          .setBitbucketCloudBindingBuilder('my-project', 'bitbucket-cloud-setting-1')
+          .withRepository('my-repo')
+          .execute();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'https://sonarqube.example.com/api/alm_settings/set_bitbucketcloud_binding',
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: 'Bearer test-token',
+            },
+            body: JSON.stringify({
+              project: 'my-project',
+              almSetting: 'bitbucket-cloud-setting-1',
+              repository: 'my-repo',
+            }),
+          }
+        );
+      });
+    });
+
+    describe('setGitHubBindingBuilder', () => {
+      it('should set GitHub binding with summary comments', async () => {
+        const mockResponse = { ok: true, text: jest.fn().mockResolvedValue('') };
+        (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+        await client
+          .setGitHubBindingBuilder('my-project', 'github-setting-1')
+          .withRepository('org/repo')
+          .withSummaryComments(true)
+          .asMonorepo()
+          .execute();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'https://sonarqube.example.com/api/alm_settings/set_github_binding',
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: 'Bearer test-token',
+            },
+            body: JSON.stringify({
+              project: 'my-project',
+              almSetting: 'github-setting-1',
+              repository: 'org/repo',
+              summaryCommentEnabled: true,
+              monorepo: true,
+            }),
+          }
+        );
+      });
+    });
+
+    describe('setGitLabBindingBuilder', () => {
+      it('should set GitLab binding', async () => {
+        const mockResponse = { ok: true, text: jest.fn().mockResolvedValue('') };
+        (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+        await client
+          .setGitLabBindingBuilder('my-project', 'gitlab-setting-1')
+          .withRepository('12345')
+          .execute();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          'https://sonarqube.example.com/api/alm_settings/set_gitlab_binding',
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: 'Bearer test-token',
+            },
+            body: JSON.stringify({
+              project: 'my-project',
+              almSetting: 'gitlab-setting-1',
+              repository: '12345',
+            }),
+          }
+        );
+      });
+    });
+  });
+});

--- a/src/resources/alm-settings/builders.ts
+++ b/src/resources/alm-settings/builders.ts
@@ -12,49 +12,57 @@ import type {
 } from './types';
 
 /**
- * Builder for creating GitHub ALM settings
+ * Base builder for GitHub ALM settings operations
  */
-export class CreateGitHubBuilder extends BaseBuilder<CreateGitHubRequest> {
-  constructor(executor: (params: CreateGitHubRequest) => Promise<void>, key: string) {
+abstract class BaseGitHubBuilder<TRequest> extends BaseBuilder<TRequest> {
+  constructor(executor: (params: TRequest) => Promise<void>, key: string) {
     super(executor);
-    this.setParam('key', key);
+    this.setParam('key' as keyof TRequest, key as TRequest[keyof TRequest]);
   }
 
   /**
    * Set the GitHub App ID
    */
   withAppId(appId: string): this {
-    return this.setParam('appId', appId);
+    return this.setParam('appId' as keyof TRequest, appId as TRequest[keyof TRequest]);
   }
 
   /**
    * Set the OAuth client ID and secret
    */
   withOAuth(clientId: string, clientSecret: string): this {
-    return this.setParams({ clientId, clientSecret });
+    return this.setParams({ clientId, clientSecret } as unknown as Partial<TRequest>);
   }
 
   /**
    * Set the private key
    */
   withPrivateKey(privateKey: string): this {
-    return this.setParam('privateKey', privateKey);
+    return this.setParam('privateKey' as keyof TRequest, privateKey as TRequest[keyof TRequest]);
   }
 
   /**
    * Set the GitHub URL (for GitHub Enterprise)
    */
   withUrl(url: string): this {
-    return this.setParam('url', url);
+    return this.setParam('url' as keyof TRequest, url as TRequest[keyof TRequest]);
   }
 
   /**
    * Set the webhook secret
    */
   withWebhookSecret(webhookSecret: string): this {
-    return this.setParam('webhookSecret', webhookSecret);
+    return this.setParam(
+      'webhookSecret' as keyof TRequest,
+      webhookSecret as TRequest[keyof TRequest]
+    );
   }
+}
 
+/**
+ * Builder for creating GitHub ALM settings
+ */
+export class CreateGitHubBuilder extends BaseGitHubBuilder<CreateGitHubRequest> {
   async execute(): Promise<void> {
     validateRequired(this.params.appId, 'GitHub App ID');
     validateOAuth(this.params.clientId, this.params.clientSecret, 'OAuth');
@@ -68,52 +76,12 @@ export class CreateGitHubBuilder extends BaseBuilder<CreateGitHubRequest> {
 /**
  * Builder for updating GitHub ALM settings
  */
-export class UpdateGitHubBuilder extends BaseBuilder<UpdateGitHubRequest> {
-  constructor(executor: (params: UpdateGitHubRequest) => Promise<void>, key: string) {
-    super(executor);
-    this.setParam('key', key);
-  }
-
+export class UpdateGitHubBuilder extends BaseGitHubBuilder<UpdateGitHubRequest> {
   /**
    * Set a new key for the ALM setting
    */
   withNewKey(newKey: string): this {
     return this.setParam('newKey', newKey);
-  }
-
-  /**
-   * Update the GitHub App ID
-   */
-  withAppId(appId: string): this {
-    return this.setParam('appId', appId);
-  }
-
-  /**
-   * Update the OAuth client ID and secret
-   */
-  withOAuth(clientId: string, clientSecret: string): this {
-    return this.setParams({ clientId, clientSecret });
-  }
-
-  /**
-   * Update the private key
-   */
-  withPrivateKey(privateKey: string): this {
-    return this.setParam('privateKey', privateKey);
-  }
-
-  /**
-   * Update the GitHub URL
-   */
-  withUrl(url: string): this {
-    return this.setParam('url', url);
-  }
-
-  /**
-   * Update the webhook secret
-   */
-  withWebhookSecret(webhookSecret: string): this {
-    return this.setParam('webhookSecret', webhookSecret);
   }
 
   async execute(): Promise<void> {
@@ -122,28 +90,33 @@ export class UpdateGitHubBuilder extends BaseBuilder<UpdateGitHubRequest> {
 }
 
 /**
- * Builder for creating Bitbucket Cloud ALM settings
+ * Base builder for Bitbucket Cloud ALM settings operations
  */
-export class CreateBitbucketCloudBuilder extends BaseBuilder<CreateBitbucketCloudRequest> {
-  constructor(executor: (params: CreateBitbucketCloudRequest) => Promise<void>, key: string) {
+abstract class BaseBitbucketCloudBuilder<TRequest> extends BaseBuilder<TRequest> {
+  constructor(executor: (params: TRequest) => Promise<void>, key: string) {
     super(executor);
-    this.setParam('key', key);
+    this.setParam('key' as keyof TRequest, key as TRequest[keyof TRequest]);
   }
 
   /**
    * Set the OAuth consumer key (client ID) and secret
    */
   withOAuth(clientId: string, clientSecret: string): this {
-    return this.setParams({ clientId, clientSecret });
+    return this.setParams({ clientId, clientSecret } as unknown as Partial<TRequest>);
   }
 
   /**
    * Set the Bitbucket workspace ID
    */
   withWorkspace(workspace: string): this {
-    return this.setParam('workspace', workspace);
+    return this.setParam('workspace' as keyof TRequest, workspace as TRequest[keyof TRequest]);
   }
+}
 
+/**
+ * Builder for creating Bitbucket Cloud ALM settings
+ */
+export class CreateBitbucketCloudBuilder extends BaseBitbucketCloudBuilder<CreateBitbucketCloudRequest> {
   async execute(): Promise<void> {
     if (!isRequired(this.params.clientId) || !isRequired(this.params.clientSecret)) {
       throw new Error('OAuth consumer key and secret are required');
@@ -157,31 +130,12 @@ export class CreateBitbucketCloudBuilder extends BaseBuilder<CreateBitbucketClou
 /**
  * Builder for updating Bitbucket Cloud ALM settings
  */
-export class UpdateBitbucketCloudBuilder extends BaseBuilder<UpdateBitbucketCloudRequest> {
-  constructor(executor: (params: UpdateBitbucketCloudRequest) => Promise<void>, key: string) {
-    super(executor);
-    this.setParam('key', key);
-  }
-
+export class UpdateBitbucketCloudBuilder extends BaseBitbucketCloudBuilder<UpdateBitbucketCloudRequest> {
   /**
    * Set a new key for the ALM setting
    */
   withNewKey(newKey: string): this {
     return this.setParam('newKey', newKey);
-  }
-
-  /**
-   * Update the OAuth consumer key (client ID) and secret
-   */
-  withOAuth(clientId: string, clientSecret: string): this {
-    return this.setParams({ clientId, clientSecret });
-  }
-
-  /**
-   * Update the Bitbucket workspace ID
-   */
-  withWorkspace(workspace: string): this {
-    return this.setParam('workspace', workspace);
   }
 
   async execute(): Promise<void> {

--- a/src/resources/alm-settings/builders.ts
+++ b/src/resources/alm-settings/builders.ts
@@ -1,3 +1,4 @@
+import { BaseBuilder, isRequired, validateRequired, validateOAuth } from '../../core/builders';
 import type {
   CreateGitHubRequest,
   UpdateGitHubRequest,
@@ -11,58 +12,9 @@ import type {
 } from './types';
 
 /**
- * Validation utilities
- */
-function isRequired(value: unknown): value is string {
-  return typeof value === 'string' && value !== '';
-}
-
-function validateRequired(value: unknown, fieldName: string): void {
-  if (!isRequired(value)) {
-    throw new Error(`${fieldName} is required`);
-  }
-}
-
-function validateOAuth(clientId: unknown, clientSecret: unknown, providerName = 'OAuth'): void {
-  if (!isRequired(clientId) || !isRequired(clientSecret)) {
-    throw new Error(`${providerName} client ID and secret are required`);
-  }
-}
-
-/**
- * Base builder for ALM settings operations
- */
-abstract class BaseAlmBuilder<TRequest> {
-  protected params: Partial<TRequest> = {};
-
-  constructor(protected executor: (params: TRequest) => Promise<void>) {}
-
-  /**
-   * Set a parameter value
-   */
-  protected setParam<K extends keyof TRequest>(key: K, value: TRequest[K]): this {
-    this.params[key] = value;
-    return this;
-  }
-
-  /**
-   * Set multiple parameters
-   */
-  protected setParams(params: Partial<TRequest>): this {
-    Object.assign(this.params, params);
-    return this;
-  }
-
-  /**
-   * Execute the operation
-   */
-  abstract execute(): Promise<void>;
-}
-
-/**
  * Builder for creating GitHub ALM settings
  */
-export class CreateGitHubBuilder extends BaseAlmBuilder<CreateGitHubRequest> {
+export class CreateGitHubBuilder extends BaseBuilder<CreateGitHubRequest> {
   constructor(executor: (params: CreateGitHubRequest) => Promise<void>, key: string) {
     super(executor);
     this.setParam('key', key);
@@ -116,7 +68,7 @@ export class CreateGitHubBuilder extends BaseAlmBuilder<CreateGitHubRequest> {
 /**
  * Builder for updating GitHub ALM settings
  */
-export class UpdateGitHubBuilder extends BaseAlmBuilder<UpdateGitHubRequest> {
+export class UpdateGitHubBuilder extends BaseBuilder<UpdateGitHubRequest> {
   constructor(executor: (params: UpdateGitHubRequest) => Promise<void>, key: string) {
     super(executor);
     this.setParam('key', key);
@@ -172,7 +124,7 @@ export class UpdateGitHubBuilder extends BaseAlmBuilder<UpdateGitHubRequest> {
 /**
  * Builder for creating Bitbucket Cloud ALM settings
  */
-export class CreateBitbucketCloudBuilder extends BaseAlmBuilder<CreateBitbucketCloudRequest> {
+export class CreateBitbucketCloudBuilder extends BaseBuilder<CreateBitbucketCloudRequest> {
   constructor(executor: (params: CreateBitbucketCloudRequest) => Promise<void>, key: string) {
     super(executor);
     this.setParam('key', key);
@@ -205,7 +157,7 @@ export class CreateBitbucketCloudBuilder extends BaseAlmBuilder<CreateBitbucketC
 /**
  * Builder for updating Bitbucket Cloud ALM settings
  */
-export class UpdateBitbucketCloudBuilder extends BaseAlmBuilder<UpdateBitbucketCloudRequest> {
+export class UpdateBitbucketCloudBuilder extends BaseBuilder<UpdateBitbucketCloudRequest> {
   constructor(executor: (params: UpdateBitbucketCloudRequest) => Promise<void>, key: string) {
     super(executor);
     this.setParam('key', key);
@@ -240,7 +192,7 @@ export class UpdateBitbucketCloudBuilder extends BaseAlmBuilder<UpdateBitbucketC
 /**
  * Base builder for project binding operations
  */
-abstract class BaseBindingBuilder<TRequest> extends BaseAlmBuilder<TRequest> {
+abstract class BaseBindingBuilder<TRequest> extends BaseBuilder<TRequest> {
   constructor(executor: (params: TRequest) => Promise<void>, project: string, almSetting: string) {
     super(executor);
     // Type assertion is safe here as all binding requests have project and almSetting fields

--- a/src/resources/alm-settings/builders.ts
+++ b/src/resources/alm-settings/builders.ts
@@ -1,0 +1,409 @@
+import type {
+  CreateGitHubRequest,
+  UpdateGitHubRequest,
+  CreateBitbucketCloudRequest,
+  UpdateBitbucketCloudRequest,
+  SetAzureBindingRequest,
+  SetBitbucketBindingRequest,
+  SetBitbucketCloudBindingRequest,
+  SetGitHubBindingRequest,
+  SetGitLabBindingRequest,
+} from './types';
+
+/**
+ * Base builder for ALM settings operations
+ */
+abstract class BaseAlmBuilder<TRequest> {
+  protected params: Partial<TRequest> = {};
+
+  constructor(protected executor: (params: TRequest) => Promise<void>) {}
+
+  /**
+   * Execute the operation
+   */
+  abstract execute(): Promise<void>;
+}
+
+/**
+ * Builder for creating GitHub ALM settings
+ */
+export class CreateGitHubBuilder extends BaseAlmBuilder<CreateGitHubRequest> {
+  constructor(executor: (params: CreateGitHubRequest) => Promise<void>, key: string) {
+    super(executor);
+    this.params.key = key;
+  }
+
+  /**
+   * Set the GitHub App ID
+   */
+  withAppId(appId: string): this {
+    this.params.appId = appId;
+    return this;
+  }
+
+  /**
+   * Set the OAuth client ID and secret
+   */
+  withOAuth(clientId: string, clientSecret: string): this {
+    this.params.clientId = clientId;
+    this.params.clientSecret = clientSecret;
+    return this;
+  }
+
+  /**
+   * Set the private key
+   */
+  withPrivateKey(privateKey: string): this {
+    this.params.privateKey = privateKey;
+    return this;
+  }
+
+  /**
+   * Set the GitHub URL (for GitHub Enterprise)
+   */
+  withUrl(url: string): this {
+    this.params.url = url;
+    return this;
+  }
+
+  /**
+   * Set the webhook secret
+   */
+  withWebhookSecret(webhookSecret: string): this {
+    this.params.webhookSecret = webhookSecret;
+    return this;
+  }
+
+  async execute(): Promise<void> {
+    if (this.params.appId === undefined || this.params.appId === '') {
+      throw new Error('GitHub App ID is required');
+    }
+    if (
+      this.params.clientId === undefined ||
+      this.params.clientId === '' ||
+      this.params.clientSecret === undefined ||
+      this.params.clientSecret === ''
+    ) {
+      throw new Error('OAuth client ID and secret are required');
+    }
+    if (this.params.privateKey === undefined || this.params.privateKey === '') {
+      throw new Error('Private key is required');
+    }
+    if (this.params.url === undefined || this.params.url === '') {
+      throw new Error('URL is required');
+    }
+
+    return this.executor(this.params as CreateGitHubRequest);
+  }
+}
+
+/**
+ * Builder for updating GitHub ALM settings
+ */
+export class UpdateGitHubBuilder extends BaseAlmBuilder<UpdateGitHubRequest> {
+  constructor(executor: (params: UpdateGitHubRequest) => Promise<void>, key: string) {
+    super(executor);
+    this.params.key = key;
+  }
+
+  /**
+   * Set a new key for the ALM setting
+   */
+  withNewKey(newKey: string): this {
+    this.params.newKey = newKey;
+    return this;
+  }
+
+  /**
+   * Update the GitHub App ID
+   */
+  withAppId(appId: string): this {
+    this.params.appId = appId;
+    return this;
+  }
+
+  /**
+   * Update the OAuth client ID and secret
+   */
+  withOAuth(clientId: string, clientSecret: string): this {
+    this.params.clientId = clientId;
+    this.params.clientSecret = clientSecret;
+    return this;
+  }
+
+  /**
+   * Update the private key
+   */
+  withPrivateKey(privateKey: string): this {
+    this.params.privateKey = privateKey;
+    return this;
+  }
+
+  /**
+   * Update the GitHub URL
+   */
+  withUrl(url: string): this {
+    this.params.url = url;
+    return this;
+  }
+
+  /**
+   * Update the webhook secret
+   */
+  withWebhookSecret(webhookSecret: string): this {
+    this.params.webhookSecret = webhookSecret;
+    return this;
+  }
+
+  async execute(): Promise<void> {
+    return this.executor(this.params as UpdateGitHubRequest);
+  }
+}
+
+/**
+ * Builder for creating Bitbucket Cloud ALM settings
+ */
+export class CreateBitbucketCloudBuilder extends BaseAlmBuilder<CreateBitbucketCloudRequest> {
+  constructor(executor: (params: CreateBitbucketCloudRequest) => Promise<void>, key: string) {
+    super(executor);
+    this.params.key = key;
+  }
+
+  /**
+   * Set the OAuth consumer key (client ID) and secret
+   */
+  withOAuth(clientId: string, clientSecret: string): this {
+    this.params.clientId = clientId;
+    this.params.clientSecret = clientSecret;
+    return this;
+  }
+
+  /**
+   * Set the Bitbucket workspace ID
+   */
+  withWorkspace(workspace: string): this {
+    this.params.workspace = workspace;
+    return this;
+  }
+
+  async execute(): Promise<void> {
+    if (
+      this.params.clientId === undefined ||
+      this.params.clientId === '' ||
+      this.params.clientSecret === undefined ||
+      this.params.clientSecret === ''
+    ) {
+      throw new Error('OAuth consumer key and secret are required');
+    }
+    if (this.params.workspace === undefined || this.params.workspace === '') {
+      throw new Error('Workspace is required');
+    }
+
+    return this.executor(this.params as CreateBitbucketCloudRequest);
+  }
+}
+
+/**
+ * Builder for updating Bitbucket Cloud ALM settings
+ */
+export class UpdateBitbucketCloudBuilder extends BaseAlmBuilder<UpdateBitbucketCloudRequest> {
+  constructor(executor: (params: UpdateBitbucketCloudRequest) => Promise<void>, key: string) {
+    super(executor);
+    this.params.key = key;
+  }
+
+  /**
+   * Set a new key for the ALM setting
+   */
+  withNewKey(newKey: string): this {
+    this.params.newKey = newKey;
+    return this;
+  }
+
+  /**
+   * Update the OAuth consumer key (client ID) and secret
+   */
+  withOAuth(clientId: string, clientSecret: string): this {
+    this.params.clientId = clientId;
+    this.params.clientSecret = clientSecret;
+    return this;
+  }
+
+  /**
+   * Update the Bitbucket workspace ID
+   */
+  withWorkspace(workspace: string): this {
+    this.params.workspace = workspace;
+    return this;
+  }
+
+  async execute(): Promise<void> {
+    return this.executor(this.params as UpdateBitbucketCloudRequest);
+  }
+}
+
+/**
+ * Base builder for project binding operations
+ */
+abstract class BaseBindingBuilder<TRequest> {
+  protected params: Partial<TRequest> = {};
+
+  constructor(
+    protected executor: (params: TRequest) => Promise<void>,
+    project: string,
+    almSetting: string
+  ) {
+    const projectParams = this.params as { project?: string; almSetting?: string };
+    projectParams.project = project;
+    projectParams.almSetting = almSetting;
+  }
+
+  /**
+   * Mark this as a monorepo binding
+   */
+  asMonorepo(): this {
+    const monorepoParams = this.params as { monorepo?: boolean };
+    monorepoParams.monorepo = true;
+    return this;
+  }
+
+  /**
+   * Execute the binding operation
+   */
+  abstract execute(): Promise<void>;
+}
+
+/**
+ * Builder for setting Azure DevOps bindings
+ */
+export class SetAzureBindingBuilder extends BaseBindingBuilder<SetAzureBindingRequest> {
+  /**
+   * Set the Azure project name
+   */
+  withProjectName(projectName: string): this {
+    this.params.projectName = projectName;
+    return this;
+  }
+
+  /**
+   * Set the Azure repository name
+   */
+  withRepository(repositoryName: string): this {
+    this.params.repositoryName = repositoryName;
+    return this;
+  }
+
+  async execute(): Promise<void> {
+    if (this.params.projectName === undefined || this.params.projectName === '') {
+      throw new Error('Azure project name is required');
+    }
+    if (this.params.repositoryName === undefined || this.params.repositoryName === '') {
+      throw new Error('Repository name is required');
+    }
+
+    return this.executor(this.params as SetAzureBindingRequest);
+  }
+}
+
+/**
+ * Builder for setting Bitbucket Server bindings
+ */
+export class SetBitbucketBindingBuilder extends BaseBindingBuilder<SetBitbucketBindingRequest> {
+  /**
+   * Set the Bitbucket repository
+   */
+  withRepository(repository: string): this {
+    this.params.repository = repository;
+    return this;
+  }
+
+  /**
+   * Set the repository slug
+   */
+  withSlug(slug: string): this {
+    this.params.slug = slug;
+    return this;
+  }
+
+  async execute(): Promise<void> {
+    if (this.params.repository === undefined || this.params.repository === '') {
+      throw new Error('Repository is required');
+    }
+    if (this.params.slug === undefined || this.params.slug === '') {
+      throw new Error('Repository slug is required');
+    }
+
+    return this.executor(this.params as SetBitbucketBindingRequest);
+  }
+}
+
+/**
+ * Builder for setting Bitbucket Cloud bindings
+ */
+export class SetBitbucketCloudBindingBuilder extends BaseBindingBuilder<SetBitbucketCloudBindingRequest> {
+  /**
+   * Set the Bitbucket repository
+   */
+  withRepository(repository: string): this {
+    this.params.repository = repository;
+    return this;
+  }
+
+  async execute(): Promise<void> {
+    if (this.params.repository === undefined || this.params.repository === '') {
+      throw new Error('Repository is required');
+    }
+
+    return this.executor(this.params as SetBitbucketCloudBindingRequest);
+  }
+}
+
+/**
+ * Builder for setting GitHub bindings
+ */
+export class SetGitHubBindingBuilder extends BaseBindingBuilder<SetGitHubBindingRequest> {
+  /**
+   * Set the GitHub repository
+   */
+  withRepository(repository: string): this {
+    this.params.repository = repository;
+    return this;
+  }
+
+  /**
+   * Enable summary comments on pull requests
+   */
+  withSummaryComments(enabled = true): this {
+    this.params.summaryCommentEnabled = enabled;
+    return this;
+  }
+
+  async execute(): Promise<void> {
+    if (this.params.repository === undefined || this.params.repository === '') {
+      throw new Error('Repository is required');
+    }
+
+    return this.executor(this.params as SetGitHubBindingRequest);
+  }
+}
+
+/**
+ * Builder for setting GitLab bindings
+ */
+export class SetGitLabBindingBuilder extends BaseBindingBuilder<SetGitLabBindingRequest> {
+  /**
+   * Set the GitLab repository
+   */
+  withRepository(repository: string): this {
+    this.params.repository = repository;
+    return this;
+  }
+
+  async execute(): Promise<void> {
+    if (this.params.repository === undefined || this.params.repository === '') {
+      throw new Error('Repository is required');
+    }
+
+    return this.executor(this.params as SetGitLabBindingRequest);
+  }
+}

--- a/src/resources/alm-settings/builders.ts
+++ b/src/resources/alm-settings/builders.ts
@@ -11,12 +11,47 @@ import type {
 } from './types';
 
 /**
+ * Validation utilities
+ */
+function isRequired(value: unknown): value is string {
+  return typeof value === 'string' && value !== '';
+}
+
+function validateRequired(value: unknown, fieldName: string): void {
+  if (!isRequired(value)) {
+    throw new Error(`${fieldName} is required`);
+  }
+}
+
+function validateOAuth(clientId: unknown, clientSecret: unknown, providerName = 'OAuth'): void {
+  if (!isRequired(clientId) || !isRequired(clientSecret)) {
+    throw new Error(`${providerName} client ID and secret are required`);
+  }
+}
+
+/**
  * Base builder for ALM settings operations
  */
 abstract class BaseAlmBuilder<TRequest> {
   protected params: Partial<TRequest> = {};
 
   constructor(protected executor: (params: TRequest) => Promise<void>) {}
+
+  /**
+   * Set a parameter value
+   */
+  protected setParam<K extends keyof TRequest>(key: K, value: TRequest[K]): this {
+    this.params[key] = value;
+    return this;
+  }
+
+  /**
+   * Set multiple parameters
+   */
+  protected setParams(params: Partial<TRequest>): this {
+    Object.assign(this.params, params);
+    return this;
+  }
 
   /**
    * Execute the operation
@@ -30,68 +65,49 @@ abstract class BaseAlmBuilder<TRequest> {
 export class CreateGitHubBuilder extends BaseAlmBuilder<CreateGitHubRequest> {
   constructor(executor: (params: CreateGitHubRequest) => Promise<void>, key: string) {
     super(executor);
-    this.params.key = key;
+    this.setParam('key', key);
   }
 
   /**
    * Set the GitHub App ID
    */
   withAppId(appId: string): this {
-    this.params.appId = appId;
-    return this;
+    return this.setParam('appId', appId);
   }
 
   /**
    * Set the OAuth client ID and secret
    */
   withOAuth(clientId: string, clientSecret: string): this {
-    this.params.clientId = clientId;
-    this.params.clientSecret = clientSecret;
-    return this;
+    return this.setParams({ clientId, clientSecret });
   }
 
   /**
    * Set the private key
    */
   withPrivateKey(privateKey: string): this {
-    this.params.privateKey = privateKey;
-    return this;
+    return this.setParam('privateKey', privateKey);
   }
 
   /**
    * Set the GitHub URL (for GitHub Enterprise)
    */
   withUrl(url: string): this {
-    this.params.url = url;
-    return this;
+    return this.setParam('url', url);
   }
 
   /**
    * Set the webhook secret
    */
   withWebhookSecret(webhookSecret: string): this {
-    this.params.webhookSecret = webhookSecret;
-    return this;
+    return this.setParam('webhookSecret', webhookSecret);
   }
 
   async execute(): Promise<void> {
-    if (this.params.appId === undefined || this.params.appId === '') {
-      throw new Error('GitHub App ID is required');
-    }
-    if (
-      this.params.clientId === undefined ||
-      this.params.clientId === '' ||
-      this.params.clientSecret === undefined ||
-      this.params.clientSecret === ''
-    ) {
-      throw new Error('OAuth client ID and secret are required');
-    }
-    if (this.params.privateKey === undefined || this.params.privateKey === '') {
-      throw new Error('Private key is required');
-    }
-    if (this.params.url === undefined || this.params.url === '') {
-      throw new Error('URL is required');
-    }
+    validateRequired(this.params.appId, 'GitHub App ID');
+    validateOAuth(this.params.clientId, this.params.clientSecret, 'OAuth');
+    validateRequired(this.params.privateKey, 'Private key');
+    validateRequired(this.params.url, 'URL');
 
     return this.executor(this.params as CreateGitHubRequest);
   }
@@ -103,56 +119,49 @@ export class CreateGitHubBuilder extends BaseAlmBuilder<CreateGitHubRequest> {
 export class UpdateGitHubBuilder extends BaseAlmBuilder<UpdateGitHubRequest> {
   constructor(executor: (params: UpdateGitHubRequest) => Promise<void>, key: string) {
     super(executor);
-    this.params.key = key;
+    this.setParam('key', key);
   }
 
   /**
    * Set a new key for the ALM setting
    */
   withNewKey(newKey: string): this {
-    this.params.newKey = newKey;
-    return this;
+    return this.setParam('newKey', newKey);
   }
 
   /**
    * Update the GitHub App ID
    */
   withAppId(appId: string): this {
-    this.params.appId = appId;
-    return this;
+    return this.setParam('appId', appId);
   }
 
   /**
    * Update the OAuth client ID and secret
    */
   withOAuth(clientId: string, clientSecret: string): this {
-    this.params.clientId = clientId;
-    this.params.clientSecret = clientSecret;
-    return this;
+    return this.setParams({ clientId, clientSecret });
   }
 
   /**
    * Update the private key
    */
   withPrivateKey(privateKey: string): this {
-    this.params.privateKey = privateKey;
-    return this;
+    return this.setParam('privateKey', privateKey);
   }
 
   /**
    * Update the GitHub URL
    */
   withUrl(url: string): this {
-    this.params.url = url;
-    return this;
+    return this.setParam('url', url);
   }
 
   /**
    * Update the webhook secret
    */
   withWebhookSecret(webhookSecret: string): this {
-    this.params.webhookSecret = webhookSecret;
-    return this;
+    return this.setParam('webhookSecret', webhookSecret);
   }
 
   async execute(): Promise<void> {
@@ -166,38 +175,28 @@ export class UpdateGitHubBuilder extends BaseAlmBuilder<UpdateGitHubRequest> {
 export class CreateBitbucketCloudBuilder extends BaseAlmBuilder<CreateBitbucketCloudRequest> {
   constructor(executor: (params: CreateBitbucketCloudRequest) => Promise<void>, key: string) {
     super(executor);
-    this.params.key = key;
+    this.setParam('key', key);
   }
 
   /**
    * Set the OAuth consumer key (client ID) and secret
    */
   withOAuth(clientId: string, clientSecret: string): this {
-    this.params.clientId = clientId;
-    this.params.clientSecret = clientSecret;
-    return this;
+    return this.setParams({ clientId, clientSecret });
   }
 
   /**
    * Set the Bitbucket workspace ID
    */
   withWorkspace(workspace: string): this {
-    this.params.workspace = workspace;
-    return this;
+    return this.setParam('workspace', workspace);
   }
 
   async execute(): Promise<void> {
-    if (
-      this.params.clientId === undefined ||
-      this.params.clientId === '' ||
-      this.params.clientSecret === undefined ||
-      this.params.clientSecret === ''
-    ) {
+    if (!isRequired(this.params.clientId) || !isRequired(this.params.clientSecret)) {
       throw new Error('OAuth consumer key and secret are required');
     }
-    if (this.params.workspace === undefined || this.params.workspace === '') {
-      throw new Error('Workspace is required');
-    }
+    validateRequired(this.params.workspace, 'Workspace');
 
     return this.executor(this.params as CreateBitbucketCloudRequest);
   }
@@ -209,32 +208,28 @@ export class CreateBitbucketCloudBuilder extends BaseAlmBuilder<CreateBitbucketC
 export class UpdateBitbucketCloudBuilder extends BaseAlmBuilder<UpdateBitbucketCloudRequest> {
   constructor(executor: (params: UpdateBitbucketCloudRequest) => Promise<void>, key: string) {
     super(executor);
-    this.params.key = key;
+    this.setParam('key', key);
   }
 
   /**
    * Set a new key for the ALM setting
    */
   withNewKey(newKey: string): this {
-    this.params.newKey = newKey;
-    return this;
+    return this.setParam('newKey', newKey);
   }
 
   /**
    * Update the OAuth consumer key (client ID) and secret
    */
   withOAuth(clientId: string, clientSecret: string): this {
-    this.params.clientId = clientId;
-    this.params.clientSecret = clientSecret;
-    return this;
+    return this.setParams({ clientId, clientSecret });
   }
 
   /**
    * Update the Bitbucket workspace ID
    */
   withWorkspace(workspace: string): this {
-    this.params.workspace = workspace;
-    return this;
+    return this.setParam('workspace', workspace);
   }
 
   async execute(): Promise<void> {
@@ -245,32 +240,19 @@ export class UpdateBitbucketCloudBuilder extends BaseAlmBuilder<UpdateBitbucketC
 /**
  * Base builder for project binding operations
  */
-abstract class BaseBindingBuilder<TRequest> {
-  protected params: Partial<TRequest> = {};
-
-  constructor(
-    protected executor: (params: TRequest) => Promise<void>,
-    project: string,
-    almSetting: string
-  ) {
-    const projectParams = this.params as { project?: string; almSetting?: string };
-    projectParams.project = project;
-    projectParams.almSetting = almSetting;
+abstract class BaseBindingBuilder<TRequest> extends BaseAlmBuilder<TRequest> {
+  constructor(executor: (params: TRequest) => Promise<void>, project: string, almSetting: string) {
+    super(executor);
+    // Type assertion is safe here as all binding requests have project and almSetting fields
+    this.setParams({ project, almSetting } as unknown as Partial<TRequest>);
   }
 
   /**
    * Mark this as a monorepo binding
    */
   asMonorepo(): this {
-    const monorepoParams = this.params as { monorepo?: boolean };
-    monorepoParams.monorepo = true;
-    return this;
+    return this.setParam('monorepo' as keyof TRequest, true as TRequest[keyof TRequest]);
   }
-
-  /**
-   * Execute the binding operation
-   */
-  abstract execute(): Promise<void>;
 }
 
 /**
@@ -281,25 +263,19 @@ export class SetAzureBindingBuilder extends BaseBindingBuilder<SetAzureBindingRe
    * Set the Azure project name
    */
   withProjectName(projectName: string): this {
-    this.params.projectName = projectName;
-    return this;
+    return this.setParam('projectName', projectName);
   }
 
   /**
    * Set the Azure repository name
    */
   withRepository(repositoryName: string): this {
-    this.params.repositoryName = repositoryName;
-    return this;
+    return this.setParam('repositoryName', repositoryName);
   }
 
   async execute(): Promise<void> {
-    if (this.params.projectName === undefined || this.params.projectName === '') {
-      throw new Error('Azure project name is required');
-    }
-    if (this.params.repositoryName === undefined || this.params.repositoryName === '') {
-      throw new Error('Repository name is required');
-    }
+    validateRequired(this.params.projectName, 'Azure project name');
+    validateRequired(this.params.repositoryName, 'Repository name');
 
     return this.executor(this.params as SetAzureBindingRequest);
   }
@@ -313,25 +289,19 @@ export class SetBitbucketBindingBuilder extends BaseBindingBuilder<SetBitbucketB
    * Set the Bitbucket repository
    */
   withRepository(repository: string): this {
-    this.params.repository = repository;
-    return this;
+    return this.setParam('repository', repository);
   }
 
   /**
    * Set the repository slug
    */
   withSlug(slug: string): this {
-    this.params.slug = slug;
-    return this;
+    return this.setParam('slug', slug);
   }
 
   async execute(): Promise<void> {
-    if (this.params.repository === undefined || this.params.repository === '') {
-      throw new Error('Repository is required');
-    }
-    if (this.params.slug === undefined || this.params.slug === '') {
-      throw new Error('Repository slug is required');
-    }
+    validateRequired(this.params.repository, 'Repository');
+    validateRequired(this.params.slug, 'Repository slug');
 
     return this.executor(this.params as SetBitbucketBindingRequest);
   }
@@ -345,14 +315,11 @@ export class SetBitbucketCloudBindingBuilder extends BaseBindingBuilder<SetBitbu
    * Set the Bitbucket repository
    */
   withRepository(repository: string): this {
-    this.params.repository = repository;
-    return this;
+    return this.setParam('repository', repository);
   }
 
   async execute(): Promise<void> {
-    if (this.params.repository === undefined || this.params.repository === '') {
-      throw new Error('Repository is required');
-    }
+    validateRequired(this.params.repository, 'Repository');
 
     return this.executor(this.params as SetBitbucketCloudBindingRequest);
   }
@@ -366,22 +333,18 @@ export class SetGitHubBindingBuilder extends BaseBindingBuilder<SetGitHubBinding
    * Set the GitHub repository
    */
   withRepository(repository: string): this {
-    this.params.repository = repository;
-    return this;
+    return this.setParam('repository', repository);
   }
 
   /**
    * Enable summary comments on pull requests
    */
   withSummaryComments(enabled = true): this {
-    this.params.summaryCommentEnabled = enabled;
-    return this;
+    return this.setParam('summaryCommentEnabled', enabled);
   }
 
   async execute(): Promise<void> {
-    if (this.params.repository === undefined || this.params.repository === '') {
-      throw new Error('Repository is required');
-    }
+    validateRequired(this.params.repository, 'Repository');
 
     return this.executor(this.params as SetGitHubBindingRequest);
   }
@@ -395,14 +358,11 @@ export class SetGitLabBindingBuilder extends BaseBindingBuilder<SetGitLabBinding
    * Set the GitLab repository
    */
   withRepository(repository: string): this {
-    this.params.repository = repository;
-    return this;
+    return this.setParam('repository', repository);
   }
 
   async execute(): Promise<void> {
-    if (this.params.repository === undefined || this.params.repository === '') {
-      throw new Error('Repository is required');
-    }
+    validateRequired(this.params.repository, 'Repository');
 
     return this.executor(this.params as SetGitLabBindingRequest);
   }

--- a/src/resources/alm-settings/index.ts
+++ b/src/resources/alm-settings/index.ts
@@ -1,5 +1,18 @@
 export { AlmSettingsClient } from './AlmSettingsClient';
 
+// Export builders
+export {
+  CreateGitHubBuilder,
+  UpdateGitHubBuilder,
+  CreateBitbucketCloudBuilder,
+  UpdateBitbucketCloudBuilder,
+  SetAzureBindingBuilder,
+  SetBitbucketBindingBuilder,
+  SetBitbucketCloudBindingBuilder,
+  SetGitHubBindingBuilder,
+  SetGitLabBindingBuilder,
+} from './builders';
+
 // Re-export all types explicitly for better compatibility
 export type {
   // Platform types

--- a/src/resources/analysis-cache/AnalysisCacheClient.ts
+++ b/src/resources/analysis-cache/AnalysisCacheClient.ts
@@ -1,0 +1,32 @@
+import { BaseClient } from '../../core/BaseClient';
+import type { GetAnalysisCacheRequest, GetAnalysisCacheResponse } from './types';
+
+/**
+ * Client for interacting with the analysis cache endpoints
+ * @since 9.4
+ */
+export class AnalysisCacheClient extends BaseClient {
+  /**
+   * Get the scanner's cached data for a branch
+   *
+   * Requires scan permission on the project.
+   * Data is returned gzipped if the corresponding 'Accept-Encoding' header is set in the request.
+   *
+   * @param params - Request parameters
+   * @returns The analysis cache data as an ArrayBuffer
+   * @since 9.4
+   */
+  async get(params: GetAnalysisCacheRequest): Promise<GetAnalysisCacheResponse> {
+    const searchParams = new URLSearchParams();
+    searchParams.append('project', params.project);
+
+    if (params.branch !== undefined) {
+      searchParams.append('branch', params.branch);
+    }
+
+    // Use BaseClient's request method with arrayBuffer response type
+    return this.request<ArrayBuffer>(`/api/analysis_cache/get?${searchParams.toString()}`, {
+      responseType: 'arrayBuffer',
+    });
+  }
+}

--- a/src/resources/analysis-cache/__tests__/AnalysisCacheClient.test.ts
+++ b/src/resources/analysis-cache/__tests__/AnalysisCacheClient.test.ts
@@ -1,0 +1,168 @@
+import { AnalysisCacheClient } from '../AnalysisCacheClient';
+
+describe('AnalysisCacheClient', () => {
+  let client: AnalysisCacheClient;
+  let clientWithoutToken: AnalysisCacheClient;
+  const baseUrl = 'https://sonarqube.example.com';
+  const token = 'test-token';
+
+  beforeEach(() => {
+    client = new AnalysisCacheClient(baseUrl, token);
+    clientWithoutToken = new AnalysisCacheClient(baseUrl);
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('get', () => {
+    it('should fetch analysis cache with project parameter', async () => {
+      const mockArrayBuffer = new ArrayBuffer(8);
+      const mockResponse = {
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(mockArrayBuffer),
+      };
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await client.get({ project: 'my-project' });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://sonarqube.example.com/api/analysis_cache/get?project=my-project',
+        {
+          headers: {
+            Authorization: 'Bearer test-token',
+          },
+          responseType: 'arrayBuffer',
+        }
+      );
+      expect(result).toBe(mockArrayBuffer);
+    });
+
+    it('should fetch analysis cache with project and branch parameters', async () => {
+      const mockArrayBuffer = new ArrayBuffer(8);
+      const mockResponse = {
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(mockArrayBuffer),
+      };
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await client.get({
+        project: 'my-project',
+        branch: 'feature/my-branch',
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://sonarqube.example.com/api/analysis_cache/get?project=my-project&branch=feature%2Fmy-branch',
+        {
+          headers: {
+            Authorization: 'Bearer test-token',
+          },
+          responseType: 'arrayBuffer',
+        }
+      );
+      expect(result).toBe(mockArrayBuffer);
+    });
+
+    it('should include authorization header when token is provided', async () => {
+      const mockArrayBuffer = new ArrayBuffer(8);
+      const mockResponse = {
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(mockArrayBuffer),
+      };
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      await client.get({ project: 'my-project' });
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0] as [
+        string,
+        RequestInit & { responseType: string },
+      ];
+      const headers = fetchCall[1].headers as Record<string, string>;
+      expect(headers['Authorization']).toBe('Bearer test-token');
+    });
+
+    it('should handle gzipped response', async () => {
+      // Create a mock gzipped array buffer
+      const gzippedData = new Uint8Array([0x1f, 0x8b, 0x08, 0x00]).buffer;
+      const mockResponse = {
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(gzippedData),
+      };
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await client.get({ project: 'my-project' });
+
+      expect(result).toBe(gzippedData);
+    });
+
+    it('should throw error on failed request', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        json: jest.fn().mockResolvedValue({
+          errors: [{ msg: 'Insufficient privileges' }],
+        }),
+      };
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      await expect(client.get({ project: 'my-project' })).rejects.toThrow(
+        'SonarQube API error: 403 Forbidden'
+      );
+    });
+
+    it('should handle empty cache data', async () => {
+      const emptyBuffer = new ArrayBuffer(0);
+      const mockResponse = {
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(emptyBuffer),
+      };
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await client.get({ project: 'my-project' });
+
+      expect(result).toBe(emptyBuffer);
+      expect(result.byteLength).toBe(0);
+    });
+
+    it('should encode special characters in parameters', async () => {
+      const mockArrayBuffer = new ArrayBuffer(8);
+      const mockResponse = {
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(mockArrayBuffer),
+      };
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      await client.get({
+        project: 'my project with spaces',
+        branch: 'feature/branch-with-#-special@chars',
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://sonarqube.example.com/api/analysis_cache/get?project=my+project+with+spaces&branch=feature%2Fbranch-with-%23-special%40chars',
+        expect.any(Object)
+      );
+    });
+
+    it('should work without authentication token', async () => {
+      const mockArrayBuffer = new ArrayBuffer(8);
+      const mockResponse = {
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(mockArrayBuffer),
+      };
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await clientWithoutToken.get({ project: 'my-project' });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://sonarqube.example.com/api/analysis_cache/get?project=my-project',
+        {
+          headers: {},
+          responseType: 'arrayBuffer',
+        }
+      );
+      expect(result).toBe(mockArrayBuffer);
+    });
+  });
+});

--- a/src/resources/analysis-cache/index.ts
+++ b/src/resources/analysis-cache/index.ts
@@ -1,0 +1,2 @@
+export { AnalysisCacheClient } from './AnalysisCacheClient';
+export type * from './types';

--- a/src/resources/analysis-cache/types.ts
+++ b/src/resources/analysis-cache/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Request parameters for getting analysis cache
+ * @since 9.4
+ */
+export interface GetAnalysisCacheRequest {
+  /**
+   * The project key
+   */
+  project: string;
+
+  /**
+   * The branch name. If not provided, the main branch is used.
+   */
+  branch?: string;
+}
+
+/**
+ * Response type for analysis cache
+ * The response is binary data (can be gzipped based on Accept-Encoding header)
+ */
+export type GetAnalysisCacheResponse = ArrayBuffer;


### PR DESCRIPTION
## Summary
- Add support for `api/analysis_cache/get` endpoint with binary response handling
- Implement builder pattern for complex ALM settings operations (4+ parameters)
- Extend BaseClient to support different response types (json, text, arrayBuffer, blob)

## Changes

### Analysis Cache Support
- New `AnalysisCacheClient` class for the `api/analysis_cache/get` endpoint
- Extended `BaseClient` to handle binary responses (arrayBuffer, blob, text)
- Integrated into main `SonarQubeClient` as `analysisCache` property
- Comprehensive tests with 100% coverage

### ALM Settings Builders
Following ADR-0003, added builders for operations with 4+ parameters:

**GitHub Operations:**
- `createGitHubBuilder()` - 7 parameters
- `updateGitHubBuilder()` - 8 parameters

**Bitbucket Cloud Operations:**
- `createBitbucketCloudBuilder()` - 4 parameters
- `updateBitbucketCloudBuilder()` - 5 parameters

**Project Binding Operations:**
- `setAzureBindingBuilder()` - 5 parameters
- `setBitbucketBindingBuilder()` - 5 parameters
- `setBitbucketCloudBindingBuilder()` - 4 parameters
- `setGitHubBindingBuilder()` - 5 parameters
- `setGitLabBindingBuilder()` - 4 parameters

## Architecture Compliance
✅ Follows modular resource-based design (ADR-0002)
✅ Implements builder pattern for complex APIs (ADR-0003)
✅ Maintains interceptor support via BaseClient (ADR-0004)
✅ Uses HTTP client abstraction (ADR-0005)

## Test plan
- [x] All new functionality has comprehensive tests
- [x] All tests pass (65 tests total)
- [x] TypeScript type checking passes
- [x] ESLint passes with no errors
- [x] Prettier formatting is correct
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)