### PR TITLE
feat: Add support for SonarQube Languages API

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ We're continuously adding support for more SonarQube/SonarCloud APIs. Here's wha
 | **Favorites** | `api/favorites` | ✅ Implemented | Both | User favorites management |
 | **Hotspots** | `api/hotspots` | ✅ Implemented | Both | Security hotspot management |
 | **Issues** | `api/issues` | ✅ Implemented | Both | Issue search and management |
-| **Languages** | `api/languages` | ❌ Not implemented | Both | Supported languages list |
+| **Languages** | `api/languages` | ✅ Implemented | Both | Supported languages list |
 | **Measures** | `api/measures` | ✅ Implemented | Both | Component measures and history |
 | **Metrics** | `api/metrics` | ✅ Implemented | Both | Metric definitions |
 | **Notifications** | `api/notifications` | ❌ Not implemented | Both | User notifications |
@@ -148,7 +148,7 @@ We're continuously adding support for more SonarQube/SonarCloud APIs. Here's wha
 | **Webhooks** | `api/webhooks` | ❌ Not implemented | Both | Webhook management |
 | **Web Services** | `api/webservices` | ❌ Not implemented | Both | API documentation |
 
-📊 **Progress**: 14 of 38 APIs implemented (37%)
+📊 **Progress**: 15 of 38 APIs implemented (39%)
 
 Want to help? Check out our [contributing guide](#🤝-contributing) - we'd love your help implementing more APIs!
 
@@ -307,6 +307,34 @@ for await (const favorite of client.favorites.searchAll()) {
 }
 ```
 
+### 🌐 Working with Languages
+
+```typescript
+// Get all supported programming languages
+const languages = await client.languages.list();
+console.log('Supported languages:', languages.languages);
+
+// Filter languages by pattern
+const javaLangs = await client.languages.list({
+  q: 'java'  // Matches 'java', 'javascript', etc.
+});
+
+// Limit the number of languages returned
+const someLanguages = await client.languages.list({
+  ps: 10  // Return only first 10 languages, 0 for all
+});
+
+// Iterate through all languages
+for await (const language of client.languages.listAll()) {
+  console.log(`Language: ${language.name} (${language.key})`);
+}
+
+// Filter while iterating
+for await (const language of client.languages.listAll({ q: 'python' })) {
+  console.log(`Found Python-related language: ${language.name}`);
+}
+```
+
 ### 💚 System Health Monitoring
 
 ```typescript
@@ -424,6 +452,7 @@ client.issues          // Issue tracking
 client.measures        // Code metrics
 client.qualityGates    // Quality gate management
 client.components      // Component navigation
+client.languages       // Programming languages
 client.sources         // Source code access
 client.system          // System administration
 // ... and many more

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { CEClient } from './resources/ce';
 import { ComponentsClient } from './resources/components';
 import { DuplicationsClient } from './resources/duplications';
 import { FavoritesClient } from './resources/favorites';
+import { LanguagesClient } from './resources/languages';
 import { ProjectsClient } from './resources/projects';
 import { MetricsClient } from './resources/metrics';
 import { MeasuresClient } from './resources/measures';
@@ -52,6 +53,8 @@ export class SonarQubeClient {
   public readonly favorites: FavoritesClient;
   /** Issues API */
   public readonly issues: IssuesClient;
+  /** Languages API */
+  public readonly languages: LanguagesClient;
   /** Security Hotspots API */
   public readonly hotspots: HotspotsClient;
   /** Projects API */
@@ -87,6 +90,7 @@ export class SonarQubeClient {
     this.duplications = new DuplicationsClient(this.baseUrl, this.token, this.organization);
     this.favorites = new FavoritesClient(this.baseUrl, this.token, this.organization);
     this.issues = new IssuesClient(this.baseUrl, this.token, this.organization);
+    this.languages = new LanguagesClient(this.baseUrl, this.token, this.organization);
     this.hotspots = new HotspotsClient(this.baseUrl, this.token, this.organization);
     this.projects = new ProjectsClient(this.baseUrl, this.token, this.organization);
     this.metrics = new MetricsClient(this.baseUrl, this.token, this.organization);
@@ -385,6 +389,13 @@ export type {
   ChangeHotspotStatusRequest,
   ChangeHotspotStatusResponse,
 } from './resources/hotspots/types';
+
+// Re-export types from languages
+export type {
+  Language,
+  ListLanguagesParams,
+  ListLanguagesResponse,
+} from './resources/languages/types';
 
 // Re-export types from quality gates
 export type {

--- a/src/resources/languages/LanguagesClient.ts
+++ b/src/resources/languages/LanguagesClient.ts
@@ -1,0 +1,65 @@
+import { BaseClient } from '../../core/BaseClient';
+import type { ListLanguagesParams, ListLanguagesResponse, Language } from './types';
+
+/**
+ * Client for interacting with SonarQube languages endpoints
+ * @since 6.3
+ */
+export class LanguagesClient extends BaseClient {
+  /**
+   * List supported programming languages
+   * @since 6.3
+   * @param params - List parameters
+   * @returns List of programming languages
+   *
+   * @example
+   * ```typescript
+   * const client = new LanguagesClient(config);
+   * const languages = await client.list({ ps: 25 });
+   * ```
+   */
+  async list(params?: ListLanguagesParams): Promise<ListLanguagesResponse> {
+    const searchParams = new URLSearchParams();
+
+    if (params?.ps !== undefined) {
+      searchParams.append('ps', String(params.ps));
+    }
+    if (params?.q !== undefined) {
+      searchParams.append('q', params.q);
+    }
+
+    const query = searchParams.toString();
+    return await this.request<ListLanguagesResponse>(
+      query ? `/api/languages/list?${query}` : '/api/languages/list'
+    );
+  }
+
+  /**
+   * List all supported programming languages using async iteration
+   * @since 6.3
+   * @param params - List parameters (ps parameter will be handled automatically)
+   * @returns Async iterator of languages
+   *
+   * @example
+   * ```typescript
+   * const client = new LanguagesClient(config);
+   * for await (const language of client.listAll({ q: 'java' })) {
+   *   console.log(language.key, language.name);
+   * }
+   * ```
+   */
+  async *listAll(
+    params?: Omit<ListLanguagesParams, 'ps'>
+  ): AsyncGenerator<Language, void, unknown> {
+    // For languages, we typically want all languages (ps=0) since
+    // the total number is usually small
+    const response = await this.list({
+      ...params,
+      ps: 0, // Get all languages
+    });
+
+    for (const language of response.languages) {
+      yield language;
+    }
+  }
+}

--- a/src/resources/languages/__tests__/LanguagesClient.test.ts
+++ b/src/resources/languages/__tests__/LanguagesClient.test.ts
@@ -1,0 +1,258 @@
+import { http, HttpResponse } from 'msw';
+import { LanguagesClient } from '../LanguagesClient';
+import { server } from '../../../test-utils/msw/server';
+import type { Language } from '../types';
+import { AuthenticationError, NotFoundError, RateLimitError, ServerError } from '../../../errors';
+import { createApiError, createErrorResponse } from '../../../test-utils/msw/factories';
+
+const createLanguage = (overrides: Partial<Language> = {}): Language => ({
+  key: 'java',
+  name: 'Java',
+  ...overrides,
+});
+
+const createLanguagesResponse = (languages: Language[]): { languages: Language[] } => ({
+  languages,
+});
+
+const SAMPLE_LANGUAGES: Record<string, Language> = {
+  java: createLanguage({ key: 'java', name: 'Java' }),
+  js: createLanguage({ key: 'js', name: 'JavaScript' }),
+  ts: createLanguage({ key: 'ts', name: 'TypeScript' }),
+  python: createLanguage({ key: 'py', name: 'Python' }),
+  csharp: createLanguage({ key: 'cs', name: 'C#' }),
+};
+
+describe('LanguagesClient', () => {
+  let client: LanguagesClient;
+  const baseUrl = 'https://sonarqube.example.com';
+  const token = 'test-token';
+
+  beforeEach(() => {
+    client = new LanguagesClient(baseUrl, token);
+  });
+
+  describe('list', () => {
+    it('should return languages with default parameters', async () => {
+      const mockResponse = createLanguagesResponse([
+        SAMPLE_LANGUAGES.java,
+        SAMPLE_LANGUAGES.js,
+        SAMPLE_LANGUAGES.python,
+      ]);
+
+      server.use(
+        http.get(`${baseUrl}/api/languages/list`, () => {
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const result = await client.list();
+
+      expect(result).toEqual(mockResponse);
+      expect(result.languages).toHaveLength(3);
+      expect(result.languages[0].key).toBe('java');
+      expect(result.languages[0].name).toBe('Java');
+    });
+
+    it('should handle list parameters correctly', async () => {
+      let capturedUrl: URL | null = null;
+
+      server.use(
+        http.get(`${baseUrl}/api/languages/list`, ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json({
+            languages: [SAMPLE_LANGUAGES.java],
+          });
+        })
+      );
+
+      await client.list({
+        ps: 25,
+        q: 'java',
+      });
+
+      expect(capturedUrl).toBeDefined();
+      expect(capturedUrl).not.toBeNull();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const params = capturedUrl!.searchParams;
+      expect(params.get('ps')).toBe('25');
+      expect(params.get('q')).toBe('java');
+    });
+
+    it('should handle empty results', async () => {
+      const mockResponse = createLanguagesResponse([]);
+
+      server.use(
+        http.get(`${baseUrl}/api/languages/list`, () => {
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const result = await client.list();
+
+      expect(result.languages).toEqual([]);
+    });
+
+    it('should handle query parameter filtering', async () => {
+      const mockResponse = createLanguagesResponse([SAMPLE_LANGUAGES.java, SAMPLE_LANGUAGES.js]);
+
+      server.use(
+        http.get(`${baseUrl}/api/languages/list`, ({ request }) => {
+          const url = new URL(request.url);
+          const query = url.searchParams.get('q');
+          expect(query).toBe('j');
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const result = await client.list({ q: 'j' });
+
+      expect(result.languages).toHaveLength(2);
+      expect(result.languages.some((lang) => lang.key === 'java')).toBe(true);
+      expect(result.languages.some((lang) => lang.key === 'js')).toBe(true);
+    });
+
+    it('should handle authentication errors', async () => {
+      server.use(
+        http.get(`${baseUrl}/api/languages/list`, () => {
+          return HttpResponse.json(
+            createErrorResponse([createApiError('Authentication required')]),
+            { status: 401 }
+          );
+        })
+      );
+
+      await expect(client.list()).rejects.toThrow(AuthenticationError);
+    });
+
+    it('should handle server errors', async () => {
+      server.use(
+        http.get(`${baseUrl}/api/languages/list`, () => {
+          return HttpResponse.json(createErrorResponse([createApiError('Internal server error')]), {
+            status: 500,
+          });
+        })
+      );
+
+      await expect(client.list()).rejects.toThrow(ServerError);
+    });
+
+    it('should handle rate limiting', async () => {
+      server.use(
+        http.get(`${baseUrl}/api/languages/list`, () => {
+          return HttpResponse.json(createErrorResponse([createApiError('Rate limit exceeded')]), {
+            status: 429,
+            headers: { 'Retry-After': '60' },
+          });
+        })
+      );
+
+      try {
+        await client.list();
+        fail('Expected RateLimitError');
+      } catch (error) {
+        expect(error).toBeInstanceOf(RateLimitError);
+        expect((error as RateLimitError).retryAfter).toBe(60);
+      }
+    });
+
+    it('should handle not found errors', async () => {
+      server.use(
+        http.get(`${baseUrl}/api/languages/list`, () => {
+          return HttpResponse.json(createErrorResponse([createApiError('Not found')]), {
+            status: 404,
+          });
+        })
+      );
+
+      await expect(client.list()).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  describe('listAll', () => {
+    it('should iterate through all languages', async () => {
+      const allLanguages = Object.values(SAMPLE_LANGUAGES);
+      const mockResponse = createLanguagesResponse(allLanguages);
+
+      server.use(
+        http.get(`${baseUrl}/api/languages/list`, ({ request }) => {
+          const url = new URL(request.url);
+          const ps = url.searchParams.get('ps');
+          expect(ps).toBe('0'); // Should request all languages
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const collectedLanguages: Language[] = [];
+
+      for await (const language of client.listAll()) {
+        collectedLanguages.push(language);
+      }
+
+      expect(collectedLanguages).toHaveLength(5);
+      expect(collectedLanguages).toEqual(allLanguages);
+    });
+
+    it('should pass through query parameter', async () => {
+      const filteredLanguages = [SAMPLE_LANGUAGES.java, SAMPLE_LANGUAGES.js];
+      let capturedUrl: URL | null = null;
+
+      server.use(
+        http.get(`${baseUrl}/api/languages/list`, ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json(createLanguagesResponse(filteredLanguages));
+        })
+      );
+
+      const languages: Language[] = [];
+
+      for await (const language of client.listAll({ q: 'j' })) {
+        languages.push(language);
+      }
+
+      expect(capturedUrl).toBeDefined();
+      expect(capturedUrl).not.toBeNull();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const params = capturedUrl!.searchParams;
+      expect(params.get('q')).toBe('j');
+      expect(params.get('ps')).toBe('0');
+      expect(languages).toHaveLength(2);
+    });
+
+    it('should handle empty results', async () => {
+      server.use(
+        http.get(`${baseUrl}/api/languages/list`, () => {
+          return HttpResponse.json(createLanguagesResponse([]));
+        })
+      );
+
+      const languages: Language[] = [];
+
+      for await (const language of client.listAll()) {
+        languages.push(language);
+      }
+
+      expect(languages).toHaveLength(0);
+    });
+
+    it('should propagate errors during iteration', async () => {
+      server.use(
+        http.get(`${baseUrl}/api/languages/list`, () => {
+          return HttpResponse.json(createErrorResponse([createApiError('Server error')]), {
+            status: 500,
+          });
+        })
+      );
+
+      const languages: Language[] = [];
+
+      await expect(async () => {
+        for await (const language of client.listAll()) {
+          languages.push(language);
+        }
+      }).rejects.toThrow(ServerError);
+
+      expect(languages).toHaveLength(0);
+    });
+  });
+});

--- a/src/resources/languages/index.ts
+++ b/src/resources/languages/index.ts
@@ -1,0 +1,4 @@
+export { LanguagesClient } from './LanguagesClient';
+
+// Re-export all types for better compatibility
+export type { Language, ListLanguagesParams, ListLanguagesResponse } from './types';

--- a/src/resources/languages/types.ts
+++ b/src/resources/languages/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Represents a programming language supported by SonarQube
+ */
+export interface Language {
+  /**
+   * Language key (e.g., "java", "js", "py")
+   */
+  key: string;
+
+  /**
+   * Human-readable language name (e.g., "Java", "JavaScript", "Python")
+   */
+  name: string;
+}
+
+/**
+ * Parameters for listing programming languages
+ */
+export interface ListLanguagesParams {
+  /**
+   * The size of the list to return, 0 for all languages
+   * @default "0"
+   */
+  ps?: number;
+
+  /**
+   * A pattern to match language keys/names against
+   */
+  q?: string;
+}
+
+/**
+ * Response from the languages list endpoint
+ */
+export interface ListLanguagesResponse {
+  /**
+   * List of programming languages
+   */
+  languages: Language[];
+}


### PR DESCRIPTION
## Summary
- Add support for the SonarQube Languages API (`api/languages`)
- Implement `LanguagesClient` with `list()` and `listAll()` methods
- Add comprehensive test coverage using MSW

## Test plan
- [x] All unit tests pass (606 tests total)
- [x] TypeScript compilation successful
- [x] Linting and formatting checks pass
- [x] Test coverage maintained at >90%
- [ ] Manual testing against actual SonarQube instance

## Changes
- Created `LanguagesClient` class extending `BaseClient`
- Added TypeScript types for `Language`, `ListLanguagesParams`, and `ListLanguagesResponse`
- Integrated languages resource into main `SonarQubeClient`
- Updated README with Languages API documentation and examples
- Exported language types from main index

## API Features
- `client.languages.list()` - Get supported programming languages
- `client.languages.listAll()` - Async iterator for all languages
- Support for filtering by query pattern (`q` parameter)
- Support for pagination (`ps` parameter)
- Full TypeScript support with proper types

## Example Usage
```typescript
// Get all languages
const languages = await client.languages.list();

// Filter languages by pattern
const javaLangs = await client.languages.list({ q: 'java' });

// Iterate through all languages
for await (const language of client.languages.listAll()) {
  console.log(`${language.name} (${language.key})`);
}
```

## Progress Update
This brings the total API coverage to 15 of 38 APIs implemented (39%).

🤖 Generated with [Claude Code](https://claude.ai/code)