### PR TITLE
feat: Add support for SonarQube Notifications API

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,39 @@ console.log('Successfully logged out');
 // Use it to check if credentials are properly configured
 ```
 
+### 🔔 Managing Notifications
+
+```typescript
+// List current user's notifications
+const result = await client.notifications.list();
+console.log('Active notifications:', result.notifications);
+console.log('Available channels:', result.channels);
+console.log('Global notification types:', result.globalTypes);
+console.log('Per-project notification types:', result.perProjectTypes);
+
+// Add a global notification for new issues assigned to me
+await client.notifications.add({
+  type: GlobalNotificationType.ChangesOnMyIssue
+});
+
+// Add a project-specific notification for quality gate changes
+await client.notifications.add({
+  type: ProjectNotificationType.NewAlerts,
+  project: 'my-project',
+  channel: NotificationChannel.Email
+});
+
+// Remove a notification
+await client.notifications.remove({
+  type: GlobalNotificationType.ChangesOnMyIssue
+});
+
+// Manage notifications for another user (requires admin permissions)
+const userNotifications = await client.notifications.list({
+  login: 'john.doe'
+});
+```
+
 ### 📋 Code Duplications
 
 ```typescript

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { ComponentsClient } from './resources/components';
 import { DuplicationsClient } from './resources/duplications';
 import { FavoritesClient } from './resources/favorites';
 import { LanguagesClient } from './resources/languages';
+import { NotificationsClient } from './resources/notifications';
 import { ProjectsClient } from './resources/projects';
 import { MetricsClient } from './resources/metrics';
 import { MeasuresClient } from './resources/measures';
@@ -57,6 +58,8 @@ export class SonarQubeClient {
   public readonly languages: LanguagesClient;
   /** Security Hotspots API */
   public readonly hotspots: HotspotsClient;
+  /** Notifications API */
+  public readonly notifications: NotificationsClient;
   /** Projects API */
   public readonly projects: ProjectsClient;
   /** Metrics API */
@@ -92,6 +95,7 @@ export class SonarQubeClient {
     this.issues = new IssuesClient(this.baseUrl, this.token, this.organization);
     this.languages = new LanguagesClient(this.baseUrl, this.token, this.organization);
     this.hotspots = new HotspotsClient(this.baseUrl, this.token, this.organization);
+    this.notifications = new NotificationsClient(this.baseUrl, this.token, this.organization);
     this.projects = new ProjectsClient(this.baseUrl, this.token, this.organization);
     this.metrics = new MetricsClient(this.baseUrl, this.token, this.organization);
     this.measures = new MeasuresClient(this.baseUrl, this.token, this.organization);
@@ -396,6 +400,22 @@ export type {
   ListLanguagesParams,
   ListLanguagesResponse,
 } from './resources/languages/types';
+
+// Re-export types from notifications
+export type {
+  NotificationAddRequest,
+  NotificationListRequest,
+  NotificationListResponse,
+  NotificationModifyResponse,
+  NotificationRemoveRequest,
+  Notification,
+  NotificationType,
+} from './resources/notifications/types';
+export {
+  NotificationChannel,
+  GlobalNotificationType,
+  ProjectNotificationType,
+} from './resources/notifications/types';
 
 // Re-export types from quality gates
 export type {

--- a/src/resources/notifications/NotificationsClient.ts
+++ b/src/resources/notifications/NotificationsClient.ts
@@ -1,0 +1,154 @@
+import { BaseClient } from '../../core/BaseClient';
+import type {
+  NotificationAddRequest,
+  NotificationListRequest,
+  NotificationListResponse,
+  NotificationModifyResponse,
+  NotificationRemoveRequest,
+} from './types';
+
+/**
+ * Client for managing notifications of the authenticated user
+ *
+ * Notifications control what events trigger alerts to users via different channels (e.g., email).
+ * Users can configure both global notifications and project-specific notifications.
+ */
+export class NotificationsClient extends BaseClient {
+  /**
+   * Add a notification for the authenticated user
+   *
+   * Requires authentication. If a project is provided, requires Browse permission on that project.
+   *
+   * @param params - Notification parameters
+   * @param params.type - Notification type (required)
+   * @param params.channel - Channel through which the notification is sent (e.g., email)
+   * @param params.login - User login (defaults to authenticated user)
+   * @param params.project - Project key for project-specific notifications
+   * @returns Promise that resolves when the notification is added
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {AuthorizationError} If the user doesn't have Browse permission on the specified project
+   * @throws {ValidationError} If the notification type is invalid for the scope (global vs project)
+   *
+   * @example
+   * ```typescript
+   * // Add a global notification for new issues assigned to me
+   * await client.notifications.add({
+   *   type: GlobalNotificationType.ChangesOnMyIssue
+   * });
+   *
+   * // Add a project-specific notification for quality gate changes
+   * await client.notifications.add({
+   *   type: ProjectNotificationType.NewAlerts,
+   *   project: 'my-project',
+   *   channel: NotificationChannel.Email
+   * });
+   * ```
+   */
+  async add(params: NotificationAddRequest): Promise<NotificationModifyResponse> {
+    const searchParams = new URLSearchParams();
+    searchParams.set('type', params.type);
+
+    if (params.channel !== undefined && params.channel !== '') {
+      searchParams.set('channel', params.channel);
+    }
+    if (params.login !== undefined && params.login !== '') {
+      searchParams.set('login', params.login);
+    }
+    if (params.project !== undefined && params.project !== '') {
+      searchParams.set('project', params.project);
+    }
+
+    await this.request(`/api/notifications/add?${searchParams.toString()}`, {
+      method: 'POST',
+    });
+  }
+
+  /**
+   * List notifications of the authenticated user
+   *
+   * Returns all configured notifications for the user, including both global
+   * and project-specific notifications, along with available notification types
+   * and channels.
+   *
+   * @param params - Optional parameters
+   * @param params.login - User login (defaults to authenticated user)
+   * @returns Promise that resolves to the list of notifications and configuration
+   * @throws {AuthenticationError} If the user is not authenticated
+   *
+   * @example
+   * ```typescript
+   * // List notifications for the authenticated user
+   * const result = await client.notifications.list();
+   * console.log('Active notifications:', result.notifications);
+   * console.log('Available channels:', result.channels);
+   * console.log('Global types:', result.globalTypes);
+   * console.log('Per-project types:', result.perProjectTypes);
+   *
+   * // List notifications for a specific user (requires admin permissions)
+   * const userNotifications = await client.notifications.list({
+   *   login: 'john.doe'
+   * });
+   * ```
+   */
+  async list(params: NotificationListRequest = {}): Promise<NotificationListResponse> {
+    const searchParams = new URLSearchParams();
+
+    if (params.login !== undefined && params.login !== '') {
+      searchParams.set('login', params.login);
+    }
+
+    const query = searchParams.toString();
+    const url = query ? `/api/notifications/list?${query}` : '/api/notifications/list';
+
+    return this.request<NotificationListResponse>(url);
+  }
+
+  /**
+   * Remove a notification for the authenticated user
+   *
+   * Removes a previously configured notification. The parameters must match
+   * exactly with the notification to be removed.
+   *
+   * @param params - Notification parameters
+   * @param params.type - Notification type (required)
+   * @param params.channel - Channel through which the notification is sent
+   * @param params.login - User login (defaults to authenticated user)
+   * @param params.project - Project key for project-specific notifications
+   * @returns Promise that resolves when the notification is removed
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {NotFoundError} If the notification doesn't exist
+   *
+   * @example
+   * ```typescript
+   * // Remove a global notification
+   * await client.notifications.remove({
+   *   type: GlobalNotificationType.ChangesOnMyIssue
+   * });
+   *
+   * // Remove a project-specific notification
+   * await client.notifications.remove({
+   *   type: ProjectNotificationType.NewAlerts,
+   *   project: 'my-project',
+   *   channel: NotificationChannel.Email
+   * });
+   * ```
+   */
+  async remove(params: NotificationRemoveRequest): Promise<NotificationModifyResponse> {
+    const searchParams = new URLSearchParams();
+    searchParams.set('type', params.type);
+
+    if (params.channel !== undefined && params.channel !== '') {
+      searchParams.set('channel', params.channel);
+    }
+    if (params.login !== undefined && params.login !== '') {
+      searchParams.set('login', params.login);
+    }
+    if (params.project !== undefined && params.project !== '') {
+      searchParams.set('project', params.project);
+    }
+
+    await this.request(`/api/notifications/remove?${searchParams.toString()}`, {
+      method: 'POST',
+    });
+  }
+}

--- a/src/resources/notifications/__tests__/NotificationsClient.test.ts
+++ b/src/resources/notifications/__tests__/NotificationsClient.test.ts
@@ -1,0 +1,263 @@
+import { http, HttpResponse } from 'msw';
+import { server } from '../../../test-utils/msw/server';
+import { assertAuthorizationHeader } from '../../../test-utils/assertions';
+import { NotificationsClient } from '../NotificationsClient';
+import { AuthenticationError, AuthorizationError, NotFoundError } from '../../../errors';
+import {
+  type NotificationListResponse,
+  GlobalNotificationType,
+  NotificationChannel,
+  ProjectNotificationType,
+} from '../types';
+
+describe('NotificationsClient', () => {
+  let client: NotificationsClient;
+  const baseUrl = 'https://sonarqube.example.com';
+  const token = 'test-token';
+
+  beforeEach(() => {
+    client = new NotificationsClient(baseUrl, token);
+  });
+
+  describe('add', () => {
+    it('should add a global notification with minimal parameters', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/notifications/add`, ({ request }) => {
+          assertAuthorizationHeader(request, token);
+          const url = new URL(request.url);
+          expect(url.searchParams.get('type')).toBe('ChangesOnMyIssue');
+          expect(url.searchParams.has('channel')).toBe(false);
+          expect(url.searchParams.has('login')).toBe(false);
+          expect(url.searchParams.has('project')).toBe(false);
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await client.add({
+        type: GlobalNotificationType.ChangesOnMyIssue,
+      });
+    });
+
+    it('should add a project notification with all parameters', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/notifications/add`, ({ request }) => {
+          assertAuthorizationHeader(request, token);
+          const url = new URL(request.url);
+          expect(url.searchParams.get('type')).toBe('NewAlerts');
+          expect(url.searchParams.get('channel')).toBe('EmailNotificationChannel');
+          expect(url.searchParams.get('login')).toBe('john.doe');
+          expect(url.searchParams.get('project')).toBe('my-project');
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await client.add({
+        type: ProjectNotificationType.NewAlerts,
+        channel: NotificationChannel.Email,
+        login: 'john.doe',
+        project: 'my-project',
+      });
+    });
+
+    it('should handle custom channel strings', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/notifications/add`, ({ request }) => {
+          assertAuthorizationHeader(request, token);
+          const url = new URL(request.url);
+          expect(url.searchParams.get('type')).toBe('CeReportTaskFailure');
+          expect(url.searchParams.get('channel')).toBe('CustomChannel');
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await client.add({
+        type: GlobalNotificationType.CeReportTaskFailure,
+        channel: 'CustomChannel',
+      });
+    });
+  });
+
+  describe('list', () => {
+    const mockResponse: NotificationListResponse = {
+      channels: ['EmailNotificationChannel'],
+      globalTypes: ['CeReportTaskFailure', 'ChangesOnMyIssue', 'SQ-MyNewIssues'],
+      perProjectTypes: [
+        'CeReportTaskFailure',
+        'ChangesOnMyIssue',
+        'NewAlerts',
+        'NewFalsePositiveIssue',
+        'NewIssues',
+        'SQ-MyNewIssues',
+      ],
+      notifications: [
+        {
+          channel: 'EmailNotificationChannel',
+          type: 'ChangesOnMyIssue',
+        },
+        {
+          channel: 'EmailNotificationChannel',
+          type: 'NewAlerts',
+          project: 'my-project',
+          projectName: 'My Project',
+        },
+      ],
+    };
+
+    it('should list notifications without parameters', async () => {
+      server.use(
+        http.get(`${baseUrl}/api/notifications/list`, ({ request }) => {
+          assertAuthorizationHeader(request, token);
+          const url = new URL(request.url);
+          expect(url.searchParams.has('login')).toBe(false);
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const result = await client.list();
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should list notifications for a specific user', async () => {
+      server.use(
+        http.get(`${baseUrl}/api/notifications/list`, ({ request }) => {
+          assertAuthorizationHeader(request, token);
+          const url = new URL(request.url);
+          expect(url.searchParams.get('login')).toBe('john.doe');
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const result = await client.list({
+        login: 'john.doe',
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should handle empty notifications list', async () => {
+      const emptyResponse: NotificationListResponse = {
+        channels: ['EmailNotificationChannel'],
+        globalTypes: ['CeReportTaskFailure', 'ChangesOnMyIssue', 'SQ-MyNewIssues'],
+        perProjectTypes: [
+          'CeReportTaskFailure',
+          'ChangesOnMyIssue',
+          'NewAlerts',
+          'NewFalsePositiveIssue',
+          'NewIssues',
+          'SQ-MyNewIssues',
+        ],
+        notifications: [],
+      };
+
+      server.use(
+        http.get(`${baseUrl}/api/notifications/list`, ({ request }) => {
+          assertAuthorizationHeader(request, token);
+          return HttpResponse.json(emptyResponse);
+        })
+      );
+
+      const result = await client.list();
+      expect(result.notifications).toHaveLength(0);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a global notification with minimal parameters', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/notifications/remove`, ({ request }) => {
+          assertAuthorizationHeader(request, token);
+          const url = new URL(request.url);
+          expect(url.searchParams.get('type')).toBe('ChangesOnMyIssue');
+          expect(url.searchParams.has('channel')).toBe(false);
+          expect(url.searchParams.has('login')).toBe(false);
+          expect(url.searchParams.has('project')).toBe(false);
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await client.remove({
+        type: GlobalNotificationType.ChangesOnMyIssue,
+      });
+    });
+
+    it('should remove a project notification with all parameters', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/notifications/remove`, ({ request }) => {
+          assertAuthorizationHeader(request, token);
+          const url = new URL(request.url);
+          expect(url.searchParams.get('type')).toBe('NewAlerts');
+          expect(url.searchParams.get('channel')).toBe('EmailNotificationChannel');
+          expect(url.searchParams.get('login')).toBe('john.doe');
+          expect(url.searchParams.get('project')).toBe('my-project');
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await client.remove({
+        type: ProjectNotificationType.NewAlerts,
+        channel: NotificationChannel.Email,
+        login: 'john.doe',
+        project: 'my-project',
+      });
+    });
+
+    it('should handle removal of notifications with custom channels', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/notifications/remove`, ({ request }) => {
+          assertAuthorizationHeader(request, token);
+          const url = new URL(request.url);
+          expect(url.searchParams.get('type')).toBe('NewIssues');
+          expect(url.searchParams.get('channel')).toBe('SlackChannel');
+          expect(url.searchParams.get('project')).toBe('my-project');
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await client.remove({
+        type: ProjectNotificationType.NewIssues,
+        channel: 'SlackChannel',
+        project: 'my-project',
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw AuthenticationError on 401', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/notifications/add`, () => {
+          return new HttpResponse(null, { status: 401 });
+        })
+      );
+
+      await expect(client.add({ type: GlobalNotificationType.ChangesOnMyIssue })).rejects.toThrow(
+        AuthenticationError
+      );
+    });
+
+    it('should throw AuthorizationError on 403 for project notifications', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/notifications/add`, () => {
+          return new HttpResponse(null, { status: 403 });
+        })
+      );
+
+      await expect(
+        client.add({
+          type: ProjectNotificationType.NewAlerts,
+          project: 'restricted-project',
+        })
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it('should throw NotFoundError when removing non-existent notifications', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/notifications/remove`, () => {
+          return new HttpResponse(null, { status: 404 });
+        })
+      );
+
+      await expect(
+        client.remove({ type: GlobalNotificationType.ChangesOnMyIssue })
+      ).rejects.toThrow(NotFoundError);
+    });
+  });
+});

--- a/src/resources/notifications/index.ts
+++ b/src/resources/notifications/index.ts
@@ -1,0 +1,11 @@
+export { NotificationsClient } from './NotificationsClient';
+export type {
+  NotificationAddRequest,
+  NotificationListRequest,
+  NotificationListResponse,
+  NotificationModifyResponse,
+  NotificationRemoveRequest,
+  Notification,
+  NotificationType,
+} from './types';
+export { NotificationChannel, GlobalNotificationType, ProjectNotificationType } from './types';

--- a/src/resources/notifications/types.ts
+++ b/src/resources/notifications/types.ts
@@ -1,0 +1,118 @@
+/**
+ * Types for the SonarQube Notifications API
+ */
+
+/**
+ * Notification channels
+ */
+export enum NotificationChannel {
+  /** Email notifications */
+  Email = 'EmailNotificationChannel',
+}
+
+/**
+ * Global notification types
+ */
+export enum GlobalNotificationType {
+  /** Background task failure */
+  CeReportTaskFailure = 'CeReportTaskFailure',
+  /** Changes on issues assigned to me */
+  ChangesOnMyIssue = 'ChangesOnMyIssue',
+  /** My new issues */
+  SQMyNewIssues = 'SQ-MyNewIssues',
+}
+
+/**
+ * Per-project notification types
+ */
+export enum ProjectNotificationType {
+  /** Background task failure on project */
+  CeReportTaskFailure = 'CeReportTaskFailure',
+  /** Changes on issues assigned to me in project */
+  ChangesOnMyIssue = 'ChangesOnMyIssue',
+  /** New quality gate status */
+  NewAlerts = 'NewAlerts',
+  /** Issues resolved as false positive or won't fix */
+  NewFalsePositiveIssue = 'NewFalsePositiveIssue',
+  /** New issues in project */
+  NewIssues = 'NewIssues',
+  /** My new issues in project */
+  SQMyNewIssues = 'SQ-MyNewIssues',
+}
+
+/**
+ * All notification types (union of global and project types)
+ */
+export type NotificationType = GlobalNotificationType | ProjectNotificationType;
+
+/**
+ * Request parameters for notifications/add
+ */
+export interface NotificationAddRequest {
+  /** Notification type */
+  type: NotificationType;
+  /** Channel through which the notification is sent */
+  channel?: NotificationChannel | string;
+  /** User login */
+  login?: string;
+  /** Project key */
+  project?: string;
+}
+
+/**
+ * Request parameters for notifications/list
+ */
+export interface NotificationListRequest {
+  /** User login */
+  login?: string;
+}
+
+/**
+ * Request parameters for notifications/remove
+ */
+export interface NotificationRemoveRequest {
+  /** Notification type */
+  type: NotificationType;
+  /** Channel through which the notification is sent */
+  channel?: NotificationChannel | string;
+  /** User login */
+  login?: string;
+  /** Project key */
+  project?: string;
+}
+
+/**
+ * Notification entity
+ */
+export interface Notification {
+  /** Notification channel */
+  channel: string;
+  /** Notification type */
+  type: string;
+  /** Organization key (if applicable) */
+  organization?: string;
+  /** Project key (if applicable) */
+  project?: string;
+  /** Project name (if applicable) */
+  projectName?: string;
+}
+
+/**
+ * Response from notifications/list
+ */
+export interface NotificationListResponse {
+  /** List of channels */
+  channels: string[];
+  /** List of global notification types */
+  globalTypes: string[];
+  /** List of per-project notification types */
+  perProjectTypes: string[];
+  /** List of active notifications */
+  notifications: Notification[];
+}
+
+/**
+ * Response from notifications/add and notifications/remove
+ * These endpoints return 204 No Content on success
+ */
+export type NotificationModifyResponse = undefined;


### PR DESCRIPTION
## Summary
- Added complete support for the SonarQube Notifications API
- Implemented add(), list(), and remove() methods for managing user notifications
- Support for both global and project-specific notifications

## Changes
- Added `NotificationsClient` class with three main methods:
  - `add()` - Add a notification for the authenticated user
  - `list()` - List all configured notifications  
  - `remove()` - Remove a notification
- Comprehensive TypeScript types including enums for notification types and channels
- Full test coverage using MSW (Mock Service Worker)
- Updated README with usage examples
- Integrated into main `SonarQubeClient` class

## Test plan
- [x] All unit tests pass (12 new tests added)
- [x] TypeScript compilation successful
- [x] ESLint checks pass
- [x] Prettier formatting applied
- [x] Coverage maintained at high level (100% for notifications module)

🤖 Generated with [Claude Code](https://claude.ai/code)