### PR TITLE
feat: Add support for SonarQube Project Links API

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ We're continuously adding support for more SonarQube/SonarCloud APIs. Here's wha
 | **Project Analyses** | `api/project_analyses` | ✅ Implemented | Both | Analysis history and events |
 | **Project Badges** | `api/project_badges` | ✅ Implemented | Both | Project status badges |
 | **Project Branches** | `api/project_branches` | ✅ Implemented | Both | Branch management |
-| **Project Links** | `api/project_links` | ❌ Not implemented | Both | Project external links |
+| **Project Links** | `api/project_links` | ✅ Implemented | Both | Project external links |
 | **Project Pull Requests** | `api/project_pull_requests` | ✅ Implemented | Both | Pull request management (Branch plugin required) |
 | **Project Tags** | `api/project_tags` | ❌ Not implemented | Both | Project tag management |
 | **Projects** | `api/projects` | ✅ Implemented | Both | Project management |

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { NotificationsClient } from './resources/notifications';
 import { ProjectsClient } from './resources/projects';
 import { ProjectBadgesClient } from './resources/project-badges';
 import { ProjectAnalysesClient } from './resources/project-analyses';
+import { ProjectLinksClient } from './resources/project-links';
 import { MetricsClient } from './resources/metrics';
 import { MeasuresClient } from './resources/measures';
 import { IssuesClient } from './resources/issues';
@@ -72,6 +73,8 @@ export class SonarQubeClient {
   public readonly projectBadges: ProjectBadgesClient;
   /** Project Analyses API */
   public readonly projectAnalyses: ProjectAnalysesClient;
+  /** Project Links API */
+  public readonly projectLinks: ProjectLinksClient;
   /** Project Pull Requests API - **Note**: Only available when the Branch plugin is installed */
   public readonly projectPullRequests: ProjectPullRequestsClient;
   /** Metrics API */
@@ -112,6 +115,7 @@ export class SonarQubeClient {
     this.projects = new ProjectsClient(this.baseUrl, this.token, this.organization);
     this.projectBadges = new ProjectBadgesClient(this.baseUrl, this.token, this.organization);
     this.projectAnalyses = new ProjectAnalysesClient(this.baseUrl, this.token, this.organization);
+    this.projectLinks = new ProjectLinksClient(this.baseUrl, this.token, this.organization);
     this.projectPullRequests = new ProjectPullRequestsClient(
       this.baseUrl,
       this.token,
@@ -477,6 +481,16 @@ export type {
   UpdateEventRequest,
   UpdateEventResponse,
 } from './resources/project-analyses/types';
+
+// Re-export types from project links
+export type {
+  ProjectLink,
+  CreateProjectLinkRequest,
+  CreateProjectLinkResponse,
+  DeleteProjectLinkRequest,
+  SearchProjectLinksRequest,
+  SearchProjectLinksResponse,
+} from './resources/project-links/types';
 
 // Re-export types from project pull requests
 export type {

--- a/src/resources/project-links/ProjectLinksClient.ts
+++ b/src/resources/project-links/ProjectLinksClient.ts
@@ -1,0 +1,119 @@
+import { BaseClient } from '../../core/BaseClient';
+import type {
+  CreateProjectLinkRequest,
+  CreateProjectLinkResponse,
+  DeleteProjectLinkRequest,
+  SearchProjectLinksRequest,
+  SearchProjectLinksResponse,
+} from './types';
+
+/**
+ * Client for managing project links in SonarQube
+ * @since 6.1
+ * @see {@link https://docs.sonarqube.org/latest/project-administration/managing-project-links/}
+ */
+export class ProjectLinksClient extends BaseClient {
+  /**
+   * Create a new project link
+   *
+   * Requires 'Administer' permission on the specified project, or global 'Administer' permission.
+   *
+   * @param request - The project link creation parameters
+   * @returns The created project link
+   * @throws {ValidationError} When required parameters are missing or invalid
+   * @throws {AuthorizationError} When the user lacks required permissions
+   *
+   * @example
+   * ```typescript
+   * const link = await client.projectLinks.create({
+   *   projectKey: 'my-project',
+   *   name: 'Documentation',
+   *   url: 'https://docs.example.com'
+   * });
+   * ```
+   *
+   * @since 6.1
+   */
+  async create(request: CreateProjectLinkRequest): Promise<CreateProjectLinkResponse> {
+    if (request.projectId === undefined && request.projectKey === undefined) {
+      throw new Error('Either projectId or projectKey must be provided');
+    }
+
+    return this.request<CreateProjectLinkResponse>('/api/project_links/create', {
+      method: 'POST',
+      body: JSON.stringify(request),
+    });
+  }
+
+  /**
+   * Delete an existing project link
+   *
+   * Requires 'Administer' permission on the specified project, or global 'Administer' permission.
+   *
+   * @param request - The deletion parameters
+   * @throws {ValidationError} When the link ID is missing
+   * @throws {NotFoundError} When the link doesn't exist
+   * @throws {AuthorizationError} When the user lacks required permissions
+   *
+   * @example
+   * ```typescript
+   * await client.projectLinks.delete({ id: '17' });
+   * ```
+   *
+   * @since 6.1
+   */
+  async delete(request: DeleteProjectLinkRequest): Promise<void> {
+    await this.request('/api/project_links/delete', {
+      method: 'POST',
+      body: JSON.stringify(request),
+    });
+  }
+
+  /**
+   * List links of a project
+   *
+   * The 'projectId' or 'projectKey' must be provided.
+   *
+   * Requires one of the following permissions:
+   * - 'Administer' rights on the specified project
+   * - 'Browse' on the specified project
+   *
+   * @param request - The search parameters
+   * @returns List of project links
+   * @throws {ValidationError} When neither projectId nor projectKey is provided
+   * @throws {NotFoundError} When the project doesn't exist
+   * @throws {AuthorizationError} When the user lacks required permissions
+   *
+   * @example
+   * ```typescript
+   * // Search by project key
+   * const links = await client.projectLinks.search({
+   *   projectKey: 'my-project'
+   * });
+   *
+   * // Search by project ID
+   * const links = await client.projectLinks.search({
+   *   projectId: 'AU-Tpxb--iU5OvuD2FLy'
+   * });
+   * ```
+   *
+   * @since 6.1
+   */
+  async search(request: SearchProjectLinksRequest): Promise<SearchProjectLinksResponse> {
+    if (request.projectId === undefined && request.projectKey === undefined) {
+      throw new Error('Either projectId or projectKey must be provided');
+    }
+
+    const params = new URLSearchParams();
+    if (request.projectId !== undefined) {
+      params.append('projectId', request.projectId);
+    }
+    if (request.projectKey !== undefined) {
+      params.append('projectKey', request.projectKey);
+    }
+
+    return this.request<SearchProjectLinksResponse>(
+      `/api/project_links/search?${params.toString()}`
+    );
+  }
+}

--- a/src/resources/project-links/__tests__/ProjectLinksClient.test.ts
+++ b/src/resources/project-links/__tests__/ProjectLinksClient.test.ts
@@ -1,0 +1,172 @@
+import { http, HttpResponse } from 'msw';
+import { ProjectLinksClient } from '../ProjectLinksClient';
+import { server } from '../../../test-utils/msw/server';
+import { assertCommonHeaders, assertQueryParams } from '../../../test-utils';
+
+describe('ProjectLinksClient', () => {
+  const baseUrl = 'http://localhost';
+  const token = 'test-token';
+  let client: ProjectLinksClient;
+
+  beforeEach(() => {
+    client = new ProjectLinksClient(baseUrl, token);
+  });
+
+  describe('create', () => {
+    it('should create a project link with project key', async () => {
+      const mockResponse = {
+        link: {
+          id: '1',
+          name: 'Documentation',
+          type: 'custom',
+          url: 'https://docs.example.com',
+        },
+      };
+
+      server.use(
+        http.post(`${baseUrl}/api/project_links/create`, async ({ request }) => {
+          assertCommonHeaders(request, token);
+          const body = await request.json();
+          expect(body).toEqual({
+            projectKey: 'my-project',
+            name: 'Documentation',
+            url: 'https://docs.example.com',
+          });
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const result = await client.create({
+        projectKey: 'my-project',
+        name: 'Documentation',
+        url: 'https://docs.example.com',
+      });
+
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should create a project link with project ID', async () => {
+      const mockResponse = {
+        link: {
+          id: '2',
+          name: 'Issue Tracker',
+          type: 'custom',
+          url: 'https://issues.example.com',
+        },
+      };
+
+      server.use(
+        http.post(`${baseUrl}/api/project_links/create`, async ({ request }) => {
+          assertCommonHeaders(request, token);
+          const body = await request.json();
+          expect(body).toEqual({
+            projectId: 'AU-Tpxb--iU5OvuD2FLy',
+            name: 'Issue Tracker',
+            url: 'https://issues.example.com',
+          });
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const result = await client.create({
+        projectId: 'AU-Tpxb--iU5OvuD2FLy',
+        name: 'Issue Tracker',
+        url: 'https://issues.example.com',
+      });
+
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should throw error when neither projectId nor projectKey is provided', async () => {
+      await expect(
+        client.create({
+          name: 'Documentation',
+          url: 'https://docs.example.com',
+        })
+      ).rejects.toThrow('Either projectId or projectKey must be provided');
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a project link', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/project_links/delete`, async ({ request }) => {
+          assertCommonHeaders(request, token);
+          const body = await request.json();
+          expect(body).toEqual({ id: '17' });
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await expect(client.delete({ id: '17' })).resolves.toBeUndefined();
+    });
+  });
+
+  describe('search', () => {
+    it('should search project links by project key', async () => {
+      const mockResponse = {
+        links: [
+          {
+            id: '1',
+            name: 'Homepage',
+            type: 'home',
+            url: 'https://example.com',
+          },
+          {
+            id: '2',
+            name: 'CI',
+            type: 'ci',
+            url: 'https://ci.example.com',
+          },
+        ],
+      };
+
+      server.use(
+        http.get(`${baseUrl}/api/project_links/search`, ({ request }) => {
+          assertCommonHeaders(request, token);
+          assertQueryParams(request, {
+            projectKey: 'my-project',
+          });
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const result = await client.search({ projectKey: 'my-project' });
+
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should search project links by project ID', async () => {
+      const mockResponse = {
+        links: [
+          {
+            id: '3',
+            name: 'Issue Tracker',
+            type: 'issue',
+            url: 'https://issues.example.com',
+          },
+        ],
+      };
+
+      server.use(
+        http.get(`${baseUrl}/api/project_links/search`, ({ request }) => {
+          assertCommonHeaders(request, token);
+          assertQueryParams(request, {
+            projectId: 'AU-Tpxb--iU5OvuD2FLy',
+          });
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const result = await client.search({ projectId: 'AU-Tpxb--iU5OvuD2FLy' });
+
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should throw error when neither projectId nor projectKey is provided', async () => {
+      await expect(client.search({})).rejects.toThrow(
+        'Either projectId or projectKey must be provided'
+      );
+    });
+  });
+});

--- a/src/resources/project-links/index.ts
+++ b/src/resources/project-links/index.ts
@@ -1,0 +1,2 @@
+export { ProjectLinksClient } from './ProjectLinksClient';
+export type * from './types';

--- a/src/resources/project-links/types.ts
+++ b/src/resources/project-links/types.ts
@@ -1,0 +1,71 @@
+/**
+ * Project link information
+ */
+export interface ProjectLink {
+  id: string;
+  name: string;
+  type: string;
+  url: string;
+}
+
+/**
+ * Request parameters for creating a project link
+ */
+export interface CreateProjectLinkRequest {
+  /**
+   * Link name
+   * @maxLength 128
+   */
+  name: string;
+  /**
+   * Project id
+   */
+  projectId?: string;
+  /**
+   * Project key
+   */
+  projectKey?: string;
+  /**
+   * Link url
+   * @maxLength 2048
+   */
+  url: string;
+}
+
+/**
+ * Response from creating a project link
+ */
+export interface CreateProjectLinkResponse {
+  link: ProjectLink;
+}
+
+/**
+ * Request parameters for deleting a project link
+ */
+export interface DeleteProjectLinkRequest {
+  /**
+   * Link id
+   */
+  id: string;
+}
+
+/**
+ * Request parameters for searching project links
+ */
+export interface SearchProjectLinksRequest {
+  /**
+   * Project Id
+   */
+  projectId?: string;
+  /**
+   * Project Key
+   */
+  projectKey?: string;
+}
+
+/**
+ * Response from searching project links
+ */
+export interface SearchProjectLinksResponse {
+  links: ProjectLink[];
+}


### PR DESCRIPTION
## Summary
- Implements the `api/project_links` endpoints for managing external links associated with projects
- Adds comprehensive TypeScript types and full test coverage
- Follows established patterns using BaseClient for HTTP operations

## Changes
- Added `ProjectLinksClient` with three methods:
  - `create()` - Create a new project link  
  - `delete()` - Delete an existing project link
  - `search()` - List links of a project
- Added TypeScript interfaces for all request/response types
- Integrated into main `SonarQubeClient` as `projectLinks` resource
- Added comprehensive test suite with MSW handlers
- Updated README to mark Project Links API as implemented

## Test plan
- [x] All unit tests pass (100% coverage for new code)
- [x] TypeScript compilation succeeds
- [x] ESLint passes with no errors
- [x] Prettier formatting applied
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)