### PR TITLE
feat: Add support for SonarQube Quality Profiles API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { HotspotsClient } from './resources/hotspots';
 import { ProjectBranchesClient } from './resources/project-branches';
 import { ProjectPullRequestsClient } from './resources/project-pull-requests';
 import { ProjectTagsClient } from './resources/project-tags';
+import { QualityProfilesClient } from './resources/quality-profiles';
 
 interface ProjectsResponse {
   [key: string]: unknown;
@@ -84,6 +85,8 @@ export class SonarQubeClient {
   public readonly measures: MeasuresClient;
   /** Quality Gates API */
   public readonly qualityGates: QualityGatesClient;
+  /** Quality Profiles API */
+  public readonly qualityProfiles: QualityProfilesClient;
   /** Sources API */
   public readonly sources: SourcesClient;
   /** System API - **Note**: Only available in SonarQube, not in SonarCloud */
@@ -127,6 +130,7 @@ export class SonarQubeClient {
     this.metrics = new MetricsClient(this.baseUrl, this.token, this.organization);
     this.measures = new MeasuresClient(this.baseUrl, this.token, this.organization);
     this.qualityGates = new QualityGatesClient(this.baseUrl, this.token, this.organization);
+    this.qualityProfiles = new QualityProfilesClient(this.baseUrl, this.token, this.organization);
     this.sources = new SourcesClient(this.baseUrl, this.token, this.organization);
     this.system = new SystemClient(this.baseUrl, this.token, this.organization);
     this.projectTags = new ProjectTagsClient(this.baseUrl, this.token, this.organization);
@@ -559,6 +563,52 @@ export type {
   SearchTagsResponse,
   SetProjectTagsParams,
 } from './resources/project-tags/types';
+
+// Re-export types from quality profiles
+export type {
+  QualityProfile,
+  Severity,
+  RuleStatus,
+  RuleType,
+  ActivateRuleRequest,
+  ActivateRulesRequest,
+  ActivateRulesResponse,
+  AddProjectRequest as QualityProfileAddProjectRequest,
+  BackupRequest as QualityProfileBackupRequest,
+  ChangeParentRequest,
+  ChangelogRequest,
+  ChangelogEntry,
+  ChangelogResponse,
+  CompareRequest as QualityProfileCompareRequest,
+  RuleComparison,
+  CompareResponse as QualityProfileCompareResponse,
+  CopyRequest as QualityProfileCopyRequest,
+  CopyResponse as QualityProfileCopyResponse,
+  CreateRequest as CreateQualityProfileRequest,
+  CreateResponse as CreateQualityProfileResponse,
+  DeactivateRuleRequest,
+  DeactivateRulesRequest,
+  DeactivateRulesResponse,
+  DeleteRequest as DeleteQualityProfileRequest,
+  ExportRequest as QualityProfileExportRequest,
+  Exporter,
+  ExportersResponse,
+  Importer,
+  ImportersResponse,
+  InheritanceRequest,
+  ProfileInheritance,
+  InheritanceResponse,
+  ProjectsRequest as QualityProfileProjectsRequest,
+  ProjectAssociation as QualityProfileProjectAssociation,
+  ProjectsResponse as QualityProfileProjectsResponse,
+  RemoveProjectRequest as QualityProfileRemoveProjectRequest,
+  RenameRequest as RenameQualityProfileRequest,
+  RestoreRequest as RestoreQualityProfileRequest,
+  RestoreResponse as RestoreQualityProfileResponse,
+  SearchRequest as SearchQualityProfilesRequest,
+  SearchResponse as SearchQualityProfilesResponse,
+  SetDefaultRequest as SetDefaultQualityProfileRequest,
+} from './resources/quality-profiles/types';
 
 // Re-export error classes
 export {

--- a/src/resources/quality-profiles/QualityProfilesClient.ts
+++ b/src/resources/quality-profiles/QualityProfilesClient.ts
@@ -1,0 +1,807 @@
+import { BaseClient } from '../../core/BaseClient';
+import { ValidationError } from '../../errors';
+import {
+  ActivateRulesBuilder,
+  ChangelogBuilder,
+  DeactivateRulesBuilder,
+  ProjectsBuilder,
+  SearchBuilder,
+} from './builders';
+import type {
+  ActivateRuleRequest,
+  AddProjectRequest,
+  BackupRequest,
+  ChangeParentRequest,
+  CompareRequest,
+  CompareResponse,
+  CopyRequest,
+  CopyResponse,
+  CreateRequest,
+  CreateResponse,
+  DeactivateRuleRequest,
+  DeleteRequest,
+  ExportRequest,
+  ExportersResponse,
+  ImportersResponse,
+  InheritanceRequest,
+  InheritanceResponse,
+  ProjectAssociation,
+  RemoveProjectRequest,
+  RenameRequest,
+  RestoreRequest,
+  RestoreResponse,
+  SetDefaultRequest,
+} from './types';
+
+/**
+ * Client for interacting with the SonarQube Quality Profiles API.
+ * Provides methods for managing quality profiles, their rules, and associations.
+ *
+ * Quality profiles are collections of rules that define code quality standards
+ * for specific programming languages in SonarQube.
+ */
+export class QualityProfilesClient extends BaseClient {
+  /**
+   * Activate a rule on a quality profile.
+   *
+   * @param params - The activation parameters
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {AuthorizationError} If the user doesn't have 'Administer Quality Profiles' permission
+   * @throws {NotFoundError} If the profile or rule doesn't exist
+   * @throws {ValidationError} If the parameters are invalid
+   *
+   * @example
+   * ```typescript
+   * // Activate a rule with default severity
+   * await client.qualityProfiles.activateRule({
+   *   key: 'java-profile-key',
+   *   rule: 'squid:S1234'
+   * });
+   *
+   * // Activate with custom severity and parameters
+   * await client.qualityProfiles.activateRule({
+   *   key: 'java-profile-key',
+   *   rule: 'squid:S1234',
+   *   severity: 'CRITICAL',
+   *   params: 'threshold=10;format=^[A-Z][a-zA-Z0-9]*$'
+   * });
+   * ```
+   */
+  async activateRule(params: ActivateRuleRequest): Promise<void> {
+    await this.request('/api/qualityprofiles/activate_rule', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+  }
+
+  /**
+   * Bulk-activate rules on a quality profile based on search criteria.
+   *
+   * @returns A builder for constructing the bulk activation request
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {AuthorizationError} If the user doesn't have 'Administer Quality Profiles' permission
+   *
+   * @example
+   * ```typescript
+   * // Activate all critical bugs
+   * const result = await client.qualityProfiles.activateRules()
+   *   .targetProfile('java-profile-key')
+   *   .severities('CRITICAL')
+   *   .types('BUG')
+   *   .execute();
+   *
+   * console.log(`Activated ${result.succeeded} rules`);
+   * ```
+   */
+  activateRules(): ActivateRulesBuilder {
+    return new ActivateRulesBuilder(async (params) => {
+      return this.request('/api/qualityprofiles/activate_rules', {
+        method: 'POST',
+        body: JSON.stringify(params),
+      });
+    });
+  }
+
+  /**
+   * Associate a project with a quality profile.
+   *
+   * @param params - The association parameters
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {AuthorizationError} If the user doesn't have 'Administer Quality Profiles' permission or 'Administer' permission on the project
+   * @throws {NotFoundError} If the profile or project doesn't exist
+   *
+   * @example
+   * ```typescript
+   * // Associate using profile key
+   * await client.qualityProfiles.addProject({
+   *   key: 'java-profile-key',
+   *   project: 'my-project'
+   * });
+   *
+   * // Associate using profile name and language
+   * await client.qualityProfiles.addProject({
+   *   qualityProfile: 'Sonar way',
+   *   language: 'java',
+   *   project: 'my-project'
+   * });
+   * ```
+   */
+  async addProject(params: AddProjectRequest): Promise<void> {
+    this.validateProfileIdentification(params);
+    this.validateProjectIdentification(params);
+    await this.request('/api/qualityprofiles/add_project', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+  }
+
+  /**
+   * Backup a quality profile in XML format.
+   * The response is the XML content that can be used with the restore endpoint.
+   *
+   * @param params - The backup parameters
+   * @returns The XML backup content
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {NotFoundError} If the profile doesn't exist
+   *
+   * @example
+   * ```typescript
+   * // Backup a profile
+   * const xml = await client.qualityProfiles.backup({
+   *   key: 'java-profile-key'
+   * });
+   *
+   * // Save to file
+   * fs.writeFileSync('profile-backup.xml', xml);
+   * ```
+   */
+  async backup(params: BackupRequest): Promise<string> {
+    this.validateProfileIdentification(params);
+    const query = new URLSearchParams();
+    if (params.key !== undefined && params.key !== '') {
+      query.append('key', params.key);
+    } else if (
+      params.qualityProfile !== undefined &&
+      params.qualityProfile !== '' &&
+      params.language !== undefined &&
+      params.language !== ''
+    ) {
+      query.append('qualityProfile', params.qualityProfile);
+      query.append('language', params.language);
+    }
+    return this.request<string>(`/api/qualityprofiles/backup?${query.toString()}`, {
+      method: 'GET',
+      responseType: 'text',
+      headers: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        Accept: 'application/xml',
+      },
+    });
+  }
+
+  /**
+   * Change a quality profile's parent profile.
+   *
+   * @param params - The parent change parameters
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {AuthorizationError} If the user doesn't have 'Administer Quality Profiles' permission
+   * @throws {NotFoundError} If either profile doesn't exist
+   * @throws {ValidationError} If the operation would create a circular inheritance
+   *
+   * @example
+   * ```typescript
+   * // Set a parent profile
+   * await client.qualityProfiles.changeParent({
+   *   key: 'custom-java-profile',
+   *   parentKey: 'company-java-base'
+   * });
+   *
+   * // Remove parent (make profile standalone)
+   * await client.qualityProfiles.changeParent({
+   *   key: 'custom-java-profile'
+   *   // parentKey omitted
+   * });
+   * ```
+   */
+  async changeParent(params: ChangeParentRequest): Promise<void> {
+    this.validateProfileIdentification(params);
+    await this.request('/api/qualityprofiles/change_parent', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+  }
+
+  /**
+   * Get the history of changes on a quality profile.
+   * Changes include rule activations/deactivations and configuration changes.
+   *
+   * @returns A builder for constructing the changelog request
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {NotFoundError} If the profile doesn't exist
+   *
+   * @example
+   * ```typescript
+   * // Get recent changes
+   * const changelog = await client.qualityProfiles.changelog()
+   *   .profile('java-profile-key')
+   *   .pageSize(50)
+   *   .execute();
+   *
+   * // Iterate through all changes since a date
+   * for await (const change of client.qualityProfiles.changelog()
+   *   .profile('java-profile-key')
+   *   .since('2024-01-01')
+   *   .all()) {
+   *   console.log(`${change.date}: ${change.action} - ${change.ruleName}`);
+   * }
+   * ```
+   */
+  changelog(): ChangelogBuilder {
+    return new ChangelogBuilder(async (params) => {
+      const query = new URLSearchParams();
+      if (params.key !== undefined && params.key !== '') {
+        query.append('key', params.key);
+      } else if (
+        params.qualityProfile !== undefined &&
+        params.qualityProfile !== '' &&
+        params.language !== undefined &&
+        params.language !== ''
+      ) {
+        query.append('qualityProfile', params.qualityProfile);
+        query.append('language', params.language);
+      }
+      if (params.p !== undefined) {
+        query.append('p', String(params.p));
+      }
+      if (params.ps !== undefined) {
+        query.append('ps', String(params.ps));
+      }
+      if (params.since !== undefined && params.since !== '') {
+        query.append('since', params.since);
+      }
+      if (params.to !== undefined && params.to !== '') {
+        query.append('to', params.to);
+      }
+
+      return this.request(`/api/qualityprofiles/changelog?${query.toString()}`);
+    });
+  }
+
+  /**
+   * Compare two quality profiles to see their differences.
+   *
+   * @param params - The comparison parameters
+   * @returns The comparison results showing rules in each profile
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {NotFoundError} If either profile doesn't exist
+   * @throws {ValidationError} If comparing profiles of different languages
+   *
+   * @example
+   * ```typescript
+   * const comparison = await client.qualityProfiles.compare({
+   *   leftKey: 'old-profile',
+   *   rightKey: 'new-profile'
+   * });
+   *
+   * console.log(`Rules only in old: ${comparison.inLeft.length}`);
+   * console.log(`Rules only in new: ${comparison.inRight.length}`);
+   * console.log(`Modified rules: ${comparison.modified.length}`);
+   * ```
+   */
+  async compare(params: CompareRequest): Promise<CompareResponse> {
+    const query = new URLSearchParams();
+    if (params.leftKey !== undefined && params.leftKey !== '') {
+      query.append('leftKey', params.leftKey);
+    } else if (params.leftQualityProfile !== undefined && params.leftQualityProfile !== '') {
+      query.append('leftQualityProfile', params.leftQualityProfile);
+    }
+    if (params.rightKey !== undefined && params.rightKey !== '') {
+      query.append('rightKey', params.rightKey);
+    } else if (params.rightQualityProfile !== undefined && params.rightQualityProfile !== '') {
+      query.append('rightQualityProfile', params.rightQualityProfile);
+    }
+
+    return this.request(`/api/qualityprofiles/compare?${query.toString()}`);
+  }
+
+  /**
+   * Copy a quality profile.
+   * The copy will have the same rules and configuration as the source.
+   *
+   * @param params - The copy parameters
+   * @returns The created profile details
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {AuthorizationError} If the user doesn't have 'Administer Quality Profiles' permission
+   * @throws {NotFoundError} If the source profile doesn't exist
+   * @throws {ValidationError} If a profile with the target name already exists
+   *
+   * @example
+   * ```typescript
+   * const newProfile = await client.qualityProfiles.copy({
+   *   fromKey: 'source-profile',
+   *   toName: 'Custom Java Profile'
+   * });
+   *
+   * console.log(`Created profile: ${newProfile.key}`);
+   * ```
+   */
+  async copy(params: CopyRequest): Promise<CopyResponse> {
+    return this.request('/api/qualityprofiles/copy', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+  }
+
+  /**
+   * Create a new quality profile.
+   *
+   * @param params - The creation parameters
+   * @returns The created profile details and any warnings
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {AuthorizationError} If the user doesn't have 'Administer Quality Profiles' permission
+   * @throws {ValidationError} If a profile with the same name and language already exists
+   *
+   * @example
+   * ```typescript
+   * const result = await client.qualityProfiles.create({
+   *   name: 'Strict Java Rules',
+   *   language: 'java'
+   * });
+   *
+   * console.log(`Created profile: ${result.profile.key}`);
+   * if (result.warnings) {
+   *   console.log('Warnings:', result.warnings);
+   * }
+   * ```
+   */
+  async create(params: CreateRequest): Promise<CreateResponse> {
+    return this.request('/api/qualityprofiles/create', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+  }
+
+  /**
+   * Deactivate a rule on a quality profile.
+   *
+   * @param params - The deactivation parameters
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {AuthorizationError} If the user doesn't have 'Administer Quality Profiles' permission
+   * @throws {NotFoundError} If the profile or rule doesn't exist
+   *
+   * @example
+   * ```typescript
+   * await client.qualityProfiles.deactivateRule({
+   *   key: 'java-profile-key',
+   *   rule: 'squid:S1234'
+   * });
+   * ```
+   */
+  async deactivateRule(params: DeactivateRuleRequest): Promise<void> {
+    await this.request('/api/qualityprofiles/deactivate_rule', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+  }
+
+  /**
+   * Bulk-deactivate rules on a quality profile based on search criteria.
+   *
+   * @returns A builder for constructing the bulk deactivation request
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {AuthorizationError} If the user doesn't have 'Administer Quality Profiles' permission
+   *
+   * @example
+   * ```typescript
+   * // Deactivate all deprecated rules
+   * const result = await client.qualityProfiles.deactivateRules()
+   *   .targetProfile('java-profile-key')
+   *   .statuses('DEPRECATED')
+   *   .execute();
+   *
+   * console.log(`Deactivated ${result.succeeded} rules`);
+   * ```
+   */
+  deactivateRules(): DeactivateRulesBuilder {
+    return new DeactivateRulesBuilder(async (params) => {
+      return this.request('/api/qualityprofiles/deactivate_rules', {
+        method: 'POST',
+        body: JSON.stringify(params),
+      });
+    });
+  }
+
+  /**
+   * Delete a quality profile and all its descendants.
+   * The default profile cannot be deleted.
+   *
+   * @param params - The deletion parameters
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {AuthorizationError} If the user doesn't have 'Administer Quality Profiles' permission
+   * @throws {NotFoundError} If the profile doesn't exist
+   * @throws {ValidationError} If trying to delete the default profile
+   *
+   * @example
+   * ```typescript
+   * await client.qualityProfiles.delete({
+   *   key: 'obsolete-profile'
+   * });
+   * ```
+   */
+  async delete(params: DeleteRequest): Promise<void> {
+    this.validateProfileIdentification(params);
+    await this.request('/api/qualityprofiles/delete', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+  }
+
+  /**
+   * Export a quality profile.
+   *
+   * @param params - The export parameters
+   * @returns The exported content (format depends on the exporter)
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {NotFoundError} If the profile doesn't exist
+   * @throws {ValidationError} If the exporter is not available for the profile's language
+   *
+   * @example
+   * ```typescript
+   * // Export using default exporter
+   * const xml = await client.qualityProfiles.export({
+   *   key: 'java-profile-key'
+   * });
+   *
+   * // Export using specific exporter
+   * const config = await client.qualityProfiles.export({
+   *   key: 'js-profile-key',
+   *   exporterKey: 'eslint'
+   * });
+   * ```
+   */
+  async export(params: ExportRequest): Promise<string> {
+    this.validateProfileIdentification(params);
+    const query = new URLSearchParams();
+    if (params.key !== undefined && params.key !== '') {
+      query.append('key', params.key);
+    } else if (
+      params.qualityProfile !== undefined &&
+      params.qualityProfile !== '' &&
+      params.language !== undefined &&
+      params.language !== ''
+    ) {
+      query.append('qualityProfile', params.qualityProfile);
+      query.append('language', params.language);
+    }
+    if (params.exporterKey !== undefined && params.exporterKey !== '') {
+      query.append('exporterKey', params.exporterKey);
+    }
+
+    return this.request<string>(`/api/qualityprofiles/export?${query.toString()}`, {
+      responseType: 'text',
+    });
+  }
+
+  /**
+   * List available profile exporters.
+   *
+   * @deprecated Since 18 March, 2025 - This endpoint will be removed
+   * @returns The list of available exporters
+   * @throws {AuthenticationError} If the user is not authenticated
+   *
+   * @example
+   * ```typescript
+   * const exporters = await client.qualityProfiles.exporters();
+   * exporters.exporters.forEach(e => {
+   *   console.log(`${e.name}: ${e.languages.join(', ')}`);
+   * });
+   * ```
+   */
+  async exporters(): Promise<ExportersResponse> {
+    return this.request('/api/qualityprofiles/exporters');
+  }
+
+  /**
+   * List supported importers.
+   *
+   * @deprecated Since 18 March, 2025 - This endpoint will be removed
+   * @returns The list of available importers
+   * @throws {AuthenticationError} If the user is not authenticated
+   *
+   * @example
+   * ```typescript
+   * const importers = await client.qualityProfiles.importers();
+   * importers.importers.forEach(i => {
+   *   console.log(`${i.name}: ${i.languages.join(', ')}`);
+   * });
+   * ```
+   */
+  async importers(): Promise<ImportersResponse> {
+    return this.request('/api/qualityprofiles/importers');
+  }
+
+  /**
+   * Show a quality profile's ancestors and children.
+   *
+   * @param params - The inheritance request parameters
+   * @returns The profile's inheritance hierarchy
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {NotFoundError} If the profile doesn't exist
+   *
+   * @example
+   * ```typescript
+   * const inheritance = await client.qualityProfiles.inheritance({
+   *   key: 'custom-java-profile'
+   * });
+   *
+   * console.log('Parent:', inheritance.ancestors[0]?.name);
+   * console.log('Children:', inheritance.children.map(c => c.name));
+   * ```
+   */
+  async inheritance(params: InheritanceRequest): Promise<InheritanceResponse> {
+    this.validateProfileIdentification(params);
+    const query = new URLSearchParams();
+    if (params.key !== undefined && params.key !== '') {
+      query.append('key', params.key);
+    } else if (
+      params.qualityProfile !== undefined &&
+      params.qualityProfile !== '' &&
+      params.language !== undefined &&
+      params.language !== ''
+    ) {
+      query.append('qualityProfile', params.qualityProfile);
+      query.append('language', params.language);
+    }
+
+    return this.request(`/api/qualityprofiles/inheritance?${query.toString()}`);
+  }
+
+  /**
+   * List projects with their association status for a quality profile.
+   *
+   * @returns A builder for constructing the projects request
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {AuthorizationError} If the user doesn't have 'Administer Quality Profiles' permission
+   * @throws {NotFoundError} If the profile doesn't exist
+   *
+   * @example
+   * ```typescript
+   * // Get associated projects
+   * const projects = await client.qualityProfiles.projects()
+   *   .profile('java-profile-key')
+   *   .selected('selected')
+   *   .execute();
+   *
+   * // Search for projects to associate
+   * for await (const project of client.qualityProfiles.projects()
+   *   .profile('java-profile-key')
+   *   .query('mobile')
+   *   .selected('deselected')
+   *   .all()) {
+   *   console.log(`Can associate: ${project.name}`);
+   * }
+   * ```
+   */
+  projects(): ProjectsBuilder {
+    return new ProjectsBuilder(async (params) => {
+      const query = new URLSearchParams();
+      query.append('key', params.key);
+      if (params.p !== undefined) {
+        query.append('p', String(params.p));
+      }
+      if (params.ps !== undefined) {
+        query.append('ps', String(params.ps));
+      }
+      if (params.q !== undefined && params.q !== '') {
+        query.append('q', params.q);
+      }
+      if (params.selected !== undefined) {
+        query.append('selected', params.selected);
+      }
+
+      return this.request(`/api/qualityprofiles/projects?${query.toString()}`);
+    });
+  }
+
+  /**
+   * Convenience method to iterate through all projects for a profile.
+   * This is equivalent to calling projects().profile(key).all()
+   *
+   * @param profileKey - The quality profile key
+   * @returns An async iterator for all projects
+   *
+   * @example
+   * ```typescript
+   * for await (const project of client.qualityProfiles.projectsAll('java-profile-key')) {
+   *   console.log(project.name, project.selected ? 'associated' : 'not associated');
+   * }
+   * ```
+   */
+  projectsAll(profileKey: string): AsyncIterableIterator<ProjectAssociation> {
+    return this.projects().profile(profileKey).pageSize(500).all();
+  }
+
+  /**
+   * Remove a project's association with a quality profile.
+   *
+   * @param params - The removal parameters
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {AuthorizationError} If the user doesn't have proper permissions
+   * @throws {NotFoundError} If the profile or project doesn't exist
+   *
+   * @example
+   * ```typescript
+   * await client.qualityProfiles.removeProject({
+   *   key: 'java-profile-key',
+   *   project: 'my-project'
+   * });
+   * ```
+   */
+  async removeProject(params: RemoveProjectRequest): Promise<void> {
+    this.validateProfileIdentification(params);
+    this.validateProjectIdentification(params);
+    await this.request('/api/qualityprofiles/remove_project', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+  }
+
+  /**
+   * Rename a quality profile.
+   *
+   * @param params - The rename parameters
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {AuthorizationError} If the user doesn't have 'Administer Quality Profiles' permission
+   * @throws {NotFoundError} If the profile doesn't exist
+   * @throws {ValidationError} If a profile with the new name already exists
+   *
+   * @example
+   * ```typescript
+   * await client.qualityProfiles.rename({
+   *   key: 'java-profile-key',
+   *   name: 'Company Java Standards v2'
+   * });
+   * ```
+   */
+  async rename(params: RenameRequest): Promise<void> {
+    await this.request('/api/qualityprofiles/rename', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+  }
+
+  /**
+   * Restore a quality profile from an XML backup.
+   * If the profile already exists, it will be updated.
+   *
+   * @param params - The restore parameters
+   * @returns Information about the restored profile
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {AuthorizationError} If the user doesn't have 'Administer Quality Profiles' permission
+   * @throws {ValidationError} If the backup content is invalid
+   *
+   * @example
+   * ```typescript
+   * const xmlContent = fs.readFileSync('profile-backup.xml', 'utf-8');
+   * const result = await client.qualityProfiles.restore({
+   *   backup: xmlContent,
+   *   organization: 'my-org'
+   * });
+   *
+   * console.log(`Restored profile: ${result.profile.name}`);
+   * console.log(`Rules restored: ${result.ruleSuccesses}`);
+   * console.log(`Rules failed: ${result.ruleFailures}`);
+   * ```
+   */
+  async restore(params: RestoreRequest): Promise<RestoreResponse> {
+    return this.request('/api/qualityprofiles/restore', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+  }
+
+  /**
+   * Search for quality profiles.
+   *
+   * @returns A builder for constructing the search request
+   * @throws {AuthenticationError} If the user is not authenticated
+   *
+   * @example
+   * ```typescript
+   * // Get default profiles
+   * const defaults = await client.qualityProfiles.search()
+   *   .defaults(true)
+   *   .execute();
+   *
+   * // Get profiles for a specific language
+   * const javaProfiles = await client.qualityProfiles.search()
+   *   .language('java')
+   *   .execute();
+   *
+   * // Get profiles used by a project
+   * const projectProfiles = await client.qualityProfiles.search()
+   *   .project('my-project')
+   *   .execute();
+   * ```
+   */
+  search(): SearchBuilder {
+    return new SearchBuilder(async (params) => {
+      const query = new URLSearchParams();
+      if (params.defaults !== undefined) {
+        query.append('defaults', String(params.defaults));
+      }
+      if (params.language !== undefined && params.language !== '') {
+        query.append('language', params.language);
+      }
+      if (params.project !== undefined && params.project !== '') {
+        query.append('project', params.project);
+      }
+      if (params.qualityProfile !== undefined && params.qualityProfile !== '') {
+        query.append('qualityProfile', params.qualityProfile);
+      }
+      if (params.organization !== undefined && params.organization !== '') {
+        query.append('organization', params.organization);
+      }
+
+      const queryString = query.toString();
+      const url = queryString
+        ? `/api/qualityprofiles/search?${queryString}`
+        : '/api/qualityprofiles/search';
+      return this.request(url);
+    });
+  }
+
+  /**
+   * Set the default profile for a given language.
+   *
+   * @param params - The default profile parameters
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {AuthorizationError} If the user doesn't have 'Administer Quality Profiles' permission
+   * @throws {NotFoundError} If the profile doesn't exist
+   *
+   * @example
+   * ```typescript
+   * await client.qualityProfiles.setDefault({
+   *   key: 'strict-java-profile'
+   * });
+   * ```
+   */
+  async setDefault(params: SetDefaultRequest): Promise<void> {
+    this.validateProfileIdentification(params);
+    await this.request('/api/qualityprofiles/set_default', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+  }
+
+  /**
+   * Validate that profile identification is provided (either key or qualityProfile+language).
+   */
+  private validateProfileIdentification(params: {
+    key?: string;
+    qualityProfile?: string;
+    language?: string;
+  }): void {
+    if (
+      (params.key === undefined || params.key === '') &&
+      (params.qualityProfile === undefined ||
+        params.qualityProfile === '' ||
+        params.language === undefined ||
+        params.language === '')
+    ) {
+      throw new ValidationError('Either key or both qualityProfile and language must be provided');
+    }
+  }
+
+  /**
+   * Validate that project identification is provided (either project or projectUuid).
+   */
+  private validateProjectIdentification(params: { project?: string; projectUuid?: string }): void {
+    if (
+      (params.project === undefined || params.project === '') &&
+      (params.projectUuid === undefined || params.projectUuid === '')
+    ) {
+      throw new ValidationError('Either project or projectUuid must be provided');
+    }
+  }
+}

--- a/src/resources/quality-profiles/__tests__/QualityProfilesClient.test.ts
+++ b/src/resources/quality-profiles/__tests__/QualityProfilesClient.test.ts
@@ -1,0 +1,659 @@
+import { http, HttpResponse } from 'msw';
+import { QualityProfilesClient } from '../QualityProfilesClient';
+import { server } from '../../../test-utils/msw/server';
+import {
+  assertAuthorizationHeader,
+  assertCommonHeaders,
+  assertRequestBody,
+  assertQueryParams,
+} from '../../../test-utils/assertions';
+import type {
+  CompareResponse,
+  CopyResponse,
+  CreateResponse,
+  ExportersResponse,
+  ImportersResponse,
+  InheritanceResponse,
+  ProjectsResponse,
+  RestoreResponse,
+} from '../types';
+
+describe('QualityProfilesClient', () => {
+  const baseUrl = 'http://localhost:9000';
+  const token = 'test-token';
+  let client: QualityProfilesClient;
+
+  beforeEach(() => {
+    client = new QualityProfilesClient(baseUrl, token);
+  });
+
+  describe('activateRule', () => {
+    it('should activate a rule on a quality profile', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/qualityprofiles/activate_rule`, async ({ request }) => {
+          assertCommonHeaders(request, token);
+          await assertRequestBody(request, {
+            key: 'java-profile-key',
+            rule: 'squid:S1234',
+          });
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await expect(
+        client.activateRule({
+          key: 'java-profile-key',
+          rule: 'squid:S1234',
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it('should activate a rule with severity and parameters', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/qualityprofiles/activate_rule`, async ({ request }) => {
+          assertCommonHeaders(request, token);
+          await assertRequestBody(request, {
+            key: 'java-profile-key',
+            rule: 'squid:S1234',
+            severity: 'CRITICAL',
+            params: 'threshold=10',
+          });
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await expect(
+        client.activateRule({
+          key: 'java-profile-key',
+          rule: 'squid:S1234',
+          severity: 'CRITICAL',
+          params: 'threshold=10',
+        })
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('activateRules', () => {
+    it('should create an ActivateRulesBuilder', () => {
+      const builder = client.activateRules();
+      expect(builder).toBeDefined();
+      expect(typeof builder.targetProfile).toBe('function');
+      expect(typeof builder.severities).toBe('function');
+      expect(typeof builder.types).toBe('function');
+    });
+  });
+
+  describe('addProject', () => {
+    it('should associate a project with a quality profile using key', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/qualityprofiles/add_project`, async ({ request }) => {
+          assertCommonHeaders(request, token);
+          await assertRequestBody(request, {
+            key: 'java-profile-key',
+            project: 'my-project',
+          });
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await expect(
+        client.addProject({
+          key: 'java-profile-key',
+          project: 'my-project',
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it('should associate a project using profile name and language', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/qualityprofiles/add_project`, async ({ request }) => {
+          assertCommonHeaders(request, token);
+          await assertRequestBody(request, {
+            qualityProfile: 'Sonar way',
+            language: 'java',
+            project: 'my-project',
+          });
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await expect(
+        client.addProject({
+          qualityProfile: 'Sonar way',
+          language: 'java',
+          project: 'my-project',
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it('should throw error when profile identification is missing', async () => {
+      await expect(
+        client.addProject({
+          project: 'my-project',
+        })
+      ).rejects.toThrow('Either key or both qualityProfile and language must be provided');
+    });
+
+    it('should throw error when project identification is missing', async () => {
+      await expect(
+        client.addProject({
+          key: 'java-profile-key',
+        })
+      ).rejects.toThrow('Either project or projectUuid must be provided');
+    });
+  });
+
+  describe('backup', () => {
+    it('should backup a quality profile by key', async () => {
+      const xmlContent = '<?xml version="1.0"?><profile>...</profile>';
+
+      server.use(
+        http.get(`${baseUrl}/api/qualityprofiles/backup`, ({ request }) => {
+          assertAuthorizationHeader(request, token);
+          assertQueryParams(request, {
+            key: 'java-profile-key',
+          });
+          return HttpResponse.text(xmlContent, {
+            headers: { 'Content-Type': 'application/xml' },
+          });
+        })
+      );
+
+      const result = await client.backup({
+        key: 'java-profile-key',
+      });
+
+      expect(result).toBe(xmlContent);
+    });
+
+    it('should backup using profile name and language', async () => {
+      const xmlContent = '<?xml version="1.0"?><profile>...</profile>';
+
+      server.use(
+        http.get(`${baseUrl}/api/qualityprofiles/backup`, ({ request }) => {
+          assertAuthorizationHeader(request, token);
+          assertQueryParams(request, {
+            qualityProfile: 'Sonar way',
+            language: 'java',
+          });
+          return HttpResponse.text(xmlContent, {
+            headers: { 'Content-Type': 'application/xml' },
+          });
+        })
+      );
+
+      const result = await client.backup({
+        qualityProfile: 'Sonar way',
+        language: 'java',
+      });
+
+      expect(result).toBe(xmlContent);
+    });
+  });
+
+  describe('changeParent', () => {
+    it('should change the parent of a quality profile', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/qualityprofiles/change_parent`, async ({ request }) => {
+          assertCommonHeaders(request, token);
+          await assertRequestBody(request, {
+            key: 'custom-java-profile',
+            parentKey: 'company-java-base',
+          });
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await expect(
+        client.changeParent({
+          key: 'custom-java-profile',
+          parentKey: 'company-java-base',
+        })
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('changelog', () => {
+    it('should create a ChangelogBuilder', () => {
+      const builder = client.changelog();
+      expect(builder).toBeDefined();
+      expect(typeof builder.profile).toBe('function');
+      expect(typeof builder.since).toBe('function');
+      expect(typeof builder.to).toBe('function');
+    });
+  });
+
+  describe('compare', () => {
+    it('should compare two quality profiles', async () => {
+      const mockResponse: CompareResponse = {
+        left: { key: 'old-profile', name: 'Old Profile' },
+        right: { key: 'new-profile', name: 'New Profile' },
+        inLeft: [],
+        inRight: [],
+        modified: [],
+        same: [],
+      };
+
+      server.use(
+        http.get(`${baseUrl}/api/qualityprofiles/compare`, ({ request }) => {
+          assertCommonHeaders(request, token);
+          assertQueryParams(request, {
+            leftKey: 'old-profile',
+            rightKey: 'new-profile',
+          });
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const result = await client.compare({
+        leftKey: 'old-profile',
+        rightKey: 'new-profile',
+      });
+
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('copy', () => {
+    it('should copy a quality profile', async () => {
+      const mockResponse: CopyResponse = {
+        key: 'new-profile-key',
+        name: 'Custom Java Profile',
+        language: 'java',
+        languageName: 'Java',
+        isInherited: false,
+      };
+
+      server.use(
+        http.post(`${baseUrl}/api/qualityprofiles/copy`, async ({ request }) => {
+          assertCommonHeaders(request, token);
+          await assertRequestBody(request, {
+            fromKey: 'source-profile',
+            toName: 'Custom Java Profile',
+          });
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const result = await client.copy({
+        fromKey: 'source-profile',
+        toName: 'Custom Java Profile',
+      });
+
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('create', () => {
+    it('should create a quality profile', async () => {
+      const mockResponse: CreateResponse = {
+        profile: {
+          key: 'new-profile-key',
+          name: 'Strict Java Rules',
+          language: 'java',
+          languageName: 'Java',
+          isInherited: false,
+          isBuiltIn: false,
+          activeRuleCount: 0,
+          activeDeprecatedRuleCount: 0,
+          isDefault: false,
+        },
+      };
+
+      server.use(
+        http.post(`${baseUrl}/api/qualityprofiles/create`, async ({ request }) => {
+          assertCommonHeaders(request, token);
+          await assertRequestBody(request, {
+            name: 'Strict Java Rules',
+            language: 'java',
+          });
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const result = await client.create({
+        name: 'Strict Java Rules',
+        language: 'java',
+      });
+
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('deactivateRule', () => {
+    it('should deactivate a rule on a quality profile', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/qualityprofiles/deactivate_rule`, async ({ request }) => {
+          assertCommonHeaders(request, token);
+          await assertRequestBody(request, {
+            key: 'java-profile-key',
+            rule: 'squid:S1234',
+          });
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await expect(
+        client.deactivateRule({
+          key: 'java-profile-key',
+          rule: 'squid:S1234',
+        })
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('deactivateRules', () => {
+    it('should create a DeactivateRulesBuilder', () => {
+      const builder = client.deactivateRules();
+      expect(builder).toBeDefined();
+      expect(typeof builder.targetProfile).toBe('function');
+      expect(typeof builder.statuses).toBe('function');
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a quality profile', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/qualityprofiles/delete`, async ({ request }) => {
+          assertCommonHeaders(request, token);
+          await assertRequestBody(request, {
+            key: 'obsolete-profile',
+          });
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await expect(
+        client.delete({
+          key: 'obsolete-profile',
+        })
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('export', () => {
+    it('should export a quality profile', async () => {
+      const xmlContent = '<?xml version="1.0"?><profile>...</profile>';
+
+      server.use(
+        http.get(`${baseUrl}/api/qualityprofiles/export`, ({ request }) => {
+          assertAuthorizationHeader(request, token);
+          assertQueryParams(request, {
+            key: 'java-profile-key',
+          });
+          return HttpResponse.text(xmlContent);
+        })
+      );
+
+      const result = await client.export({
+        key: 'java-profile-key',
+      });
+
+      expect(result).toBe(xmlContent);
+    });
+
+    it('should export with specific exporter', async () => {
+      const configContent = 'eslint config content';
+
+      server.use(
+        http.get(`${baseUrl}/api/qualityprofiles/export`, ({ request }) => {
+          assertAuthorizationHeader(request, token);
+          assertQueryParams(request, {
+            key: 'js-profile-key',
+            exporterKey: 'eslint',
+          });
+          return HttpResponse.text(configContent);
+        })
+      );
+
+      const result = await client.export({
+        key: 'js-profile-key',
+        exporterKey: 'eslint',
+      });
+
+      expect(result).toBe(configContent);
+    });
+  });
+
+  describe('exporters', () => {
+    it('should list available exporters', async () => {
+      const mockResponse: ExportersResponse = {
+        exporters: [
+          { key: 'eslint', name: 'ESLint', languages: ['js', 'ts'] },
+          { key: 'checkstyle', name: 'Checkstyle', languages: ['java'] },
+        ],
+      };
+
+      server.use(
+        http.get(`${baseUrl}/api/qualityprofiles/exporters`, ({ request }) => {
+          assertCommonHeaders(request, token);
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      const result = await client.exporters();
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('importers', () => {
+    it('should list available importers', async () => {
+      const mockResponse: ImportersResponse = {
+        importers: [
+          { key: 'eslint', name: 'ESLint', languages: ['js', 'ts'] },
+          { key: 'checkstyle', name: 'Checkstyle', languages: ['java'] },
+        ],
+      };
+
+      server.use(
+        http.get(`${baseUrl}/api/qualityprofiles/importers`, ({ request }) => {
+          assertCommonHeaders(request, token);
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      const result = await client.importers();
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('inheritance', () => {
+    it('should get profile inheritance information', async () => {
+      const mockResponse: InheritanceResponse = {
+        profile: {
+          key: 'custom-java-profile',
+          name: 'Custom Java',
+          language: 'java',
+          languageName: 'Java',
+          isInherited: true,
+          isBuiltIn: false,
+          activeRuleCount: 150,
+          activeDeprecatedRuleCount: 5,
+          isDefault: false,
+          parentKey: 'company-base',
+        },
+        ancestors: [
+          {
+            key: 'company-base',
+            name: 'Company Base',
+            activeRuleCount: 100,
+            isBuiltIn: false,
+          },
+        ],
+        children: [],
+      };
+
+      server.use(
+        http.get(`${baseUrl}/api/qualityprofiles/inheritance`, ({ request }) => {
+          assertCommonHeaders(request, token);
+          assertQueryParams(request, {
+            key: 'custom-java-profile',
+          });
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const result = await client.inheritance({
+        key: 'custom-java-profile',
+      });
+
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('projects', () => {
+    it('should create a ProjectsBuilder', () => {
+      const builder = client.projects();
+      expect(builder).toBeDefined();
+      expect(typeof builder.profile).toBe('function');
+      expect(typeof builder.query).toBe('function');
+      expect(typeof builder.selected).toBe('function');
+    });
+  });
+
+  describe('projectsAll', () => {
+    it('should return an async iterator for all projects', async () => {
+      const mockResponse: ProjectsResponse = {
+        results: [
+          { id: '1', key: 'project1', name: 'Project 1', selected: true },
+          { id: '2', key: 'project2', name: 'Project 2', selected: false },
+        ],
+        paging: { pageIndex: 1, pageSize: 2, total: 2 },
+      };
+
+      server.use(
+        http.get(`${baseUrl}/api/qualityprofiles/projects`, ({ request }) => {
+          assertCommonHeaders(request, token);
+          assertQueryParams(request, {
+            key: 'java-profile-key',
+            p: '1',
+            ps: '500',
+          });
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const projects = [];
+      for await (const project of client.projectsAll('java-profile-key')) {
+        projects.push(project);
+      }
+
+      expect(projects).toHaveLength(2);
+      expect(projects[0].name).toBe('Project 1');
+      expect(projects[1].name).toBe('Project 2');
+    });
+  });
+
+  describe('removeProject', () => {
+    it('should remove project association', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/qualityprofiles/remove_project`, async ({ request }) => {
+          assertCommonHeaders(request, token);
+          await assertRequestBody(request, {
+            key: 'java-profile-key',
+            project: 'my-project',
+          });
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await expect(
+        client.removeProject({
+          key: 'java-profile-key',
+          project: 'my-project',
+        })
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('rename', () => {
+    it('should rename a quality profile', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/qualityprofiles/rename`, async ({ request }) => {
+          assertCommonHeaders(request, token);
+          await assertRequestBody(request, {
+            key: 'java-profile-key',
+            name: 'Company Java Standards v2',
+          });
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await expect(
+        client.rename({
+          key: 'java-profile-key',
+          name: 'Company Java Standards v2',
+        })
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('restore', () => {
+    it('should restore a quality profile from backup', async () => {
+      const mockResponse: RestoreResponse = {
+        profile: {
+          key: 'restored-profile-key',
+          name: 'Restored Profile',
+          language: 'java',
+          languageName: 'Java',
+          isInherited: false,
+          isBuiltIn: false,
+          activeRuleCount: 95,
+          activeDeprecatedRuleCount: 2,
+          isDefault: false,
+        },
+        ruleSuccesses: 95,
+        ruleFailures: 5,
+      };
+
+      server.use(
+        http.post(`${baseUrl}/api/qualityprofiles/restore`, async ({ request }) => {
+          assertCommonHeaders(request, token);
+          const body = await request.json();
+          expect(body).toHaveProperty('backup');
+          expect(body).toHaveProperty('organization', 'my-org');
+          return HttpResponse.json(mockResponse);
+        })
+      );
+
+      const result = await client.restore({
+        backup: '<?xml version="1.0"?><profile>...</profile>',
+        organization: 'my-org',
+      });
+
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('search', () => {
+    it('should create a SearchBuilder', () => {
+      const builder = client.search();
+      expect(builder).toBeDefined();
+      expect(typeof builder.defaults).toBe('function');
+      expect(typeof builder.language).toBe('function');
+      expect(typeof builder.project).toBe('function');
+    });
+  });
+
+  describe('setDefault', () => {
+    it('should set a profile as default', async () => {
+      server.use(
+        http.post(`${baseUrl}/api/qualityprofiles/set_default`, async ({ request }) => {
+          assertCommonHeaders(request, token);
+          await assertRequestBody(request, {
+            key: 'strict-java-profile',
+          });
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      await expect(
+        client.setDefault({
+          key: 'strict-java-profile',
+        })
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/resources/quality-profiles/__tests__/builders.test.ts
+++ b/src/resources/quality-profiles/__tests__/builders.test.ts
@@ -1,0 +1,269 @@
+import {
+  ActivateRulesBuilder,
+  ChangelogBuilder,
+  DeactivateRulesBuilder,
+  ProjectsBuilder,
+  SearchBuilder,
+} from '../builders';
+import type {
+  ActivateRulesResponse,
+  ChangelogResponse,
+  ProjectsResponse,
+  SearchResponse,
+} from '../types';
+
+describe('Quality Profiles Builders', () => {
+  describe('ActivateRulesBuilder', () => {
+    it('should build activate rules request with required parameters', async () => {
+      const mockExecutor = jest.fn().mockResolvedValue({
+        succeeded: 10,
+        failed: 0,
+      } as ActivateRulesResponse);
+
+      const builder = new ActivateRulesBuilder(mockExecutor);
+      await builder.targetProfile('java-profile-key').execute();
+
+      expect(mockExecutor).toHaveBeenCalledWith({
+        targetKey: 'java-profile-key',
+      });
+    });
+
+    it('should build request with all parameters', async () => {
+      const mockExecutor = jest.fn().mockResolvedValue({
+        succeeded: 5,
+        failed: 0,
+      } as ActivateRulesResponse);
+
+      const builder = new ActivateRulesBuilder(mockExecutor);
+      await builder
+        .targetProfile('java-profile-key')
+        .severities('CRITICAL,MAJOR')
+        .types('BUG,VULNERABILITY')
+        .repositories('squid,pmd')
+        .targetSeverity('BLOCKER')
+        .languages('java')
+        .tags('security')
+        .activation(true)
+        .availableSince('2024-01-01')
+        .execute();
+
+      expect(mockExecutor).toHaveBeenCalledWith({
+        targetKey: 'java-profile-key',
+        severities: 'CRITICAL,MAJOR',
+        types: 'BUG,VULNERABILITY',
+        repositories: 'squid,pmd',
+        targetSeverity: 'BLOCKER',
+        languages: 'java',
+        tags: 'security',
+        activation: true,
+        available_since: '2024-01-01',
+      });
+    });
+
+    it('should throw error when target profile is not provided', async () => {
+      const mockExecutor = jest.fn();
+      const builder = new ActivateRulesBuilder(mockExecutor);
+
+      await expect(builder.execute()).rejects.toThrow('Target profile key is required');
+      expect(mockExecutor).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DeactivateRulesBuilder', () => {
+    it('should extend ActivateRulesBuilder and work correctly', async () => {
+      const mockExecutor = jest.fn().mockResolvedValue({
+        succeeded: 3,
+        failed: 0,
+      } as ActivateRulesResponse);
+
+      const builder = new DeactivateRulesBuilder(mockExecutor);
+      await builder.targetProfile('java-profile-key').statuses('DEPRECATED').execute();
+
+      expect(mockExecutor).toHaveBeenCalledWith({
+        targetKey: 'java-profile-key',
+        statuses: 'DEPRECATED',
+      });
+    });
+  });
+
+  describe('ChangelogBuilder', () => {
+    const mockResponse: ChangelogResponse = {
+      events: [
+        {
+          date: '2024-01-15T10:30:00+0000',
+          action: 'ACTIVATED',
+          ruleKey: 'squid:S1234',
+          ruleName: 'Rule Name',
+        },
+      ],
+      paging: { pageIndex: 1, pageSize: 50, total: 1 },
+    };
+
+    it('should build changelog request with profile key', async () => {
+      const mockExecutor = jest.fn().mockResolvedValue(mockResponse);
+      const builder = new ChangelogBuilder(mockExecutor);
+
+      await builder.profile('java-profile-key').execute();
+
+      expect(mockExecutor).toHaveBeenCalledWith({
+        key: 'java-profile-key',
+      });
+    });
+
+    it('should build request with profile name and language', async () => {
+      const mockExecutor = jest.fn().mockResolvedValue(mockResponse);
+      const builder = new ChangelogBuilder(mockExecutor);
+
+      await builder.profileByName('Sonar way', 'java').execute();
+
+      expect(mockExecutor).toHaveBeenCalledWith({
+        qualityProfile: 'Sonar way',
+        language: 'java',
+      });
+    });
+
+    it('should support date filters and pagination', async () => {
+      const mockExecutor = jest.fn().mockResolvedValue(mockResponse);
+      const builder = new ChangelogBuilder(mockExecutor);
+
+      await builder
+        .profile('java-profile-key')
+        .since('2024-01-01')
+        .to('2024-12-31')
+        .page(2)
+        .pageSize(100)
+        .execute();
+
+      expect(mockExecutor).toHaveBeenCalledWith({
+        key: 'java-profile-key',
+        since: '2024-01-01',
+        to: '2024-12-31',
+        p: 2,
+        ps: 100,
+      });
+    });
+
+    it('should throw error when profile identification is missing', async () => {
+      const mockExecutor = jest.fn();
+      const builder = new ChangelogBuilder(mockExecutor);
+
+      await expect(builder.execute()).rejects.toThrow(
+        'Either key or both qualityProfile and language must be provided'
+      );
+    });
+
+    it('should support async iteration', async () => {
+      const mockExecutor = jest
+        .fn()
+        .mockResolvedValueOnce({
+          events: [
+            { date: '2024-01-01', action: 'ACTIVATED', ruleKey: 'rule1', ruleName: 'Rule 1' },
+            { date: '2024-01-02', action: 'DEACTIVATED', ruleKey: 'rule2', ruleName: 'Rule 2' },
+          ],
+          paging: { pageIndex: 1, pageSize: 2, total: 3 },
+        })
+        .mockResolvedValueOnce({
+          events: [{ date: '2024-01-03', action: 'UPDATED', ruleKey: 'rule3', ruleName: 'Rule 3' }],
+          paging: { pageIndex: 2, pageSize: 2, total: 3 },
+        });
+
+      const builder = new ChangelogBuilder(mockExecutor);
+      const items = [];
+
+      for await (const item of builder.profile('java-profile-key').all()) {
+        items.push(item);
+      }
+
+      expect(items).toHaveLength(3);
+      expect(items[0].ruleKey).toBe('rule1');
+      expect(items[1].ruleKey).toBe('rule2');
+      expect(items[2].ruleKey).toBe('rule3');
+    });
+  });
+
+  describe('ProjectsBuilder', () => {
+    const mockResponse: ProjectsResponse = {
+      results: [{ id: '1', key: 'project1', name: 'Project 1', selected: true }],
+      paging: { pageIndex: 1, pageSize: 50, total: 1 },
+    };
+
+    it('should build projects request with required profile key', async () => {
+      const mockExecutor = jest.fn().mockResolvedValue(mockResponse);
+      const builder = new ProjectsBuilder(mockExecutor);
+
+      await builder.profile('java-profile-key').execute();
+
+      expect(mockExecutor).toHaveBeenCalledWith({
+        key: 'java-profile-key',
+      });
+    });
+
+    it('should support query and selection filter', async () => {
+      const mockExecutor = jest.fn().mockResolvedValue(mockResponse);
+      const builder = new ProjectsBuilder(mockExecutor);
+
+      await builder.profile('java-profile-key').query('mobile').selected('deselected').execute();
+
+      expect(mockExecutor).toHaveBeenCalledWith({
+        key: 'java-profile-key',
+        q: 'mobile',
+        selected: 'deselected',
+      });
+    });
+
+    it('should throw error when profile key is not provided', async () => {
+      const mockExecutor = jest.fn();
+      const builder = new ProjectsBuilder(mockExecutor);
+
+      await expect(builder.execute()).rejects.toThrow('Profile key is required');
+    });
+  });
+
+  describe('SearchBuilder', () => {
+    const mockResponse: SearchResponse = {
+      profiles: [
+        {
+          key: 'java-profile',
+          name: 'Java Profile',
+          language: 'java',
+          languageName: 'Java',
+          isInherited: false,
+          isBuiltIn: false,
+          activeRuleCount: 100,
+          activeDeprecatedRuleCount: 0,
+          isDefault: true,
+        },
+      ],
+    };
+
+    it('should build search request with no parameters', async () => {
+      const mockExecutor = jest.fn().mockResolvedValue(mockResponse);
+      const builder = new SearchBuilder(mockExecutor);
+
+      await builder.execute();
+
+      expect(mockExecutor).toHaveBeenCalledWith({});
+    });
+
+    it('should build request with all parameters', async () => {
+      const mockExecutor = jest.fn().mockResolvedValue(mockResponse);
+      const builder = new SearchBuilder(mockExecutor);
+
+      await builder
+        .defaults(true)
+        .language('java')
+        .project('my-project')
+        .qualityProfile('Sonar way')
+        .organization('my-org')
+        .execute();
+
+      expect(mockExecutor).toHaveBeenCalledWith({
+        defaults: true,
+        language: 'java',
+        project: 'my-project',
+        qualityProfile: 'Sonar way',
+        organization: 'my-org',
+      });
+    });
+  });
+});

--- a/src/resources/quality-profiles/builders.ts
+++ b/src/resources/quality-profiles/builders.ts
@@ -1,0 +1,397 @@
+/* eslint-disable @typescript-eslint/member-ordering */
+import { BaseBuilder, PaginatedBuilder, ParameterHelpers } from '../../core/builders';
+import { ValidationError } from '../../errors';
+import type {
+  ActivateRulesRequest,
+  ActivateRulesResponse,
+  ChangelogEntry,
+  ChangelogRequest,
+  ChangelogResponse,
+  DeactivateRulesRequest,
+  DeactivateRulesResponse,
+  ProjectAssociation,
+  ProjectsRequest,
+  ProjectsResponse,
+  SearchRequest,
+  SearchResponse,
+  Severity,
+} from './types';
+
+/**
+ * Builder for activating rules in bulk on a quality profile.
+ * Provides a fluent interface for constructing complex rule activation queries.
+ *
+ * @example
+ * ```typescript
+ * // Activate all critical bugs
+ * const result = await client.qualityProfiles.activateRules()
+ *   .targetProfile('java-profile-key')
+ *   .severities(['CRITICAL'])
+ *   .types(['BUG'])
+ *   .targetSeverity('BLOCKER')
+ *   .execute();
+ *
+ * // Activate rules from specific repositories
+ * const result = await client.qualityProfiles.activateRules()
+ *   .targetProfile('js-profile-key')
+ *   .repositories(['eslint', 'tslint'])
+ *   .execute();
+ * ```
+ */
+export class ActivateRulesBuilder extends BaseBuilder<ActivateRulesRequest, ActivateRulesResponse> {
+  /**
+   * Set the target quality profile key (required).
+   */
+  targetProfile(key: string): this {
+    this.params.targetKey = key;
+    return this;
+  }
+
+  /**
+   * Filter on activation status.
+   */
+  activation = ParameterHelpers.createBooleanMethod<typeof this>('activation');
+
+  /**
+   * Comma-separated list of activation severities.
+   */
+  activeSeverities = ParameterHelpers.createStringMethod<typeof this>('active_severities');
+
+  /**
+   * Ascending sort.
+   */
+  ascending = ParameterHelpers.createBooleanMethod<typeof this>('asc');
+
+  /**
+   * Filter rules available since a date.
+   */
+  availableSince = ParameterHelpers.createStringMethod<typeof this>('available_since');
+
+  /**
+   * Comma-separated list of CWE identifiers.
+   */
+  cwe = ParameterHelpers.createStringMethod<typeof this>('cwe');
+
+  /**
+   * Filter by inheritance.
+   */
+  inheritance = ParameterHelpers.createStringMethod<typeof this>('inheritance');
+
+  /**
+   * Filter template rules.
+   */
+  isTemplate = ParameterHelpers.createBooleanMethod<typeof this>('is_template');
+
+  /**
+   * Comma-separated list of languages.
+   */
+  languages = ParameterHelpers.createStringMethod<typeof this>('languages');
+
+  /**
+   * Comma-separated list of OWASP Top 10 2017 categories.
+   */
+  owaspTop10 = ParameterHelpers.createStringMethod<typeof this>('owaspTop10');
+
+  /**
+   * Comma-separated list of OWASP Top 10 2021 categories.
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  owaspTop10_2021 = ParameterHelpers.createStringMethod<typeof this>('owaspTop10_2021');
+
+  /**
+   * 1-based page number.
+   */
+  page(value: number): this {
+    this.params.p = value;
+    return this;
+  }
+
+  /**
+   * Page size.
+   */
+  pageSize(value: number): this {
+    this.params.ps = value;
+    return this;
+  }
+
+  /**
+   * Search query.
+   */
+  query = ParameterHelpers.createStringMethod<typeof this>('q');
+
+  /**
+   * Quality profile key to filter rules.
+   */
+  qualityProfile = ParameterHelpers.createStringMethod<typeof this>('qprofile');
+
+  /**
+   * Comma-separated list of repositories.
+   */
+  repositories = ParameterHelpers.createStringMethod<typeof this>('repositories');
+
+  /**
+   * Rule key.
+   */
+  ruleKey = ParameterHelpers.createStringMethod<typeof this>('rule_key');
+
+  /**
+   * Sort field.
+   */
+  sortBy = ParameterHelpers.createStringMethod<typeof this>('s');
+
+  /**
+   * Comma-separated list of SANS Top 25 categories.
+   */
+  sansTop25 = ParameterHelpers.createStringMethod<typeof this>('sans_top25');
+
+  /**
+   * Comma-separated list of severities.
+   */
+  severities = ParameterHelpers.createStringMethod<typeof this>('severities');
+
+  /**
+   * Comma-separated list of SonarSource security categories.
+   */
+  sonarsourceSecurity = ParameterHelpers.createStringMethod<typeof this>('sonarsource_security');
+
+  /**
+   * Comma-separated list of statuses.
+   */
+  statuses = ParameterHelpers.createStringMethod<typeof this>('statuses');
+
+  /**
+   * Comma-separated list of tags.
+   */
+  tags = ParameterHelpers.createStringMethod<typeof this>('tags');
+
+  /**
+   * Severity to set on activated rules.
+   */
+  targetSeverity(severity: Severity): this {
+    this.params.targetSeverity = severity;
+    return this;
+  }
+
+  /**
+   * Template key.
+   */
+  templateKey = ParameterHelpers.createStringMethod<typeof this>('template_key');
+
+  /**
+   * Comma-separated list of types.
+   */
+  types = ParameterHelpers.createStringMethod<typeof this>('types');
+
+  async execute(): Promise<ActivateRulesResponse> {
+    const finalParams = this.params as ActivateRulesRequest;
+    if (!finalParams.targetKey) {
+      throw new ValidationError('Target profile key is required');
+    }
+    return this.executor(finalParams);
+  }
+}
+
+/**
+ * Builder for deactivating rules in bulk on a quality profile.
+ * Extends ActivateRulesBuilder with the same filtering capabilities.
+ *
+ * @example
+ * ```typescript
+ * // Deactivate deprecated rules
+ * const result = await client.qualityProfiles.deactivateRules()
+ *   .targetProfile('java-profile-key')
+ *   .statuses(['DEPRECATED'])
+ *   .execute();
+ * ```
+ */
+export class DeactivateRulesBuilder extends ActivateRulesBuilder {
+  constructor(executor: (params: DeactivateRulesRequest) => Promise<DeactivateRulesResponse>) {
+    // Override the executor with proper typing
+    super(async (params: ActivateRulesRequest) => {
+      // Call the deactivate executor with the same params
+      return executor(params) as unknown as Promise<ActivateRulesResponse>;
+    });
+  }
+
+  override async execute(): Promise<DeactivateRulesResponse> {
+    const result = await super.execute();
+
+    return result;
+  }
+}
+
+/**
+ * Builder for paginated quality profile changelog requests.
+ *
+ * @example
+ * ```typescript
+ * // Get recent changes
+ * const changelog = await client.qualityProfiles.changelog()
+ *   .profile('java-profile-key')
+ *   .pageSize(50)
+ *   .execute();
+ *
+ * // Iterate through all changes
+ * for await (const change of client.qualityProfiles.changelog()
+ *   .profile('java-profile-key')
+ *   .since('2024-01-01')
+ *   .all()) {
+ *   console.log(change.action, change.ruleKey);
+ * }
+ * ```
+ */
+export class ChangelogBuilder extends PaginatedBuilder<
+  ChangelogRequest,
+  ChangelogResponse,
+  ChangelogEntry
+> {
+  /**
+   * Set the quality profile key.
+   */
+  profile(key: string): this {
+    this.params.key = key;
+    return this;
+  }
+
+  /**
+   * Set the quality profile name and language.
+   */
+  profileByName(name: string, language: string): this {
+    this.params.qualityProfile = name;
+    this.params.language = language;
+    return this;
+  }
+
+  /**
+   * Filter changes after this date.
+   */
+  since = ParameterHelpers.createStringMethod<typeof this>('since');
+
+  /**
+   * Filter changes before this date.
+   */
+  to = ParameterHelpers.createStringMethod<typeof this>('to');
+
+  protected getItems(response: ChangelogResponse): ChangelogEntry[] {
+    return response.events;
+  }
+
+  async execute(): Promise<ChangelogResponse> {
+    const finalParams = this.params as ChangelogRequest;
+    if (
+      (finalParams.key === undefined || finalParams.key === '') &&
+      (finalParams.qualityProfile === undefined ||
+        finalParams.qualityProfile === '' ||
+        finalParams.language === undefined ||
+        finalParams.language === '')
+    ) {
+      throw new ValidationError('Either key or both qualityProfile and language must be provided');
+    }
+    return this.executor(finalParams);
+  }
+}
+
+/**
+ * Builder for paginated quality profile projects requests.
+ *
+ * @example
+ * ```typescript
+ * // Get associated projects
+ * const projects = await client.qualityProfiles.projects()
+ *   .profile('java-profile-key')
+ *   .selected('selected')
+ *   .execute();
+ *
+ * // Search for projects
+ * const projects = await client.qualityProfiles.projects()
+ *   .profile('java-profile-key')
+ *   .query('mobile')
+ *   .all();
+ * ```
+ */
+export class ProjectsBuilder extends PaginatedBuilder<
+  ProjectsRequest,
+  ProjectsResponse,
+  ProjectAssociation
+> {
+  /**
+   * Set the quality profile key (required).
+   */
+  profile(key: string): this {
+    this.params.key = key;
+    return this;
+  }
+
+  /**
+   * Search query for project name.
+   */
+  query = ParameterHelpers.createStringMethod<typeof this>('q');
+
+  /**
+   * Filter by selection status.
+   */
+  selected(value: 'all' | 'selected' | 'deselected'): this {
+    this.params.selected = value;
+    return this;
+  }
+
+  protected getItems(response: ProjectsResponse): ProjectAssociation[] {
+    return response.results;
+  }
+
+  async execute(): Promise<ProjectsResponse> {
+    const finalParams = this.params as ProjectsRequest;
+    if (!finalParams.key) {
+      throw new ValidationError('Profile key is required');
+    }
+    return this.executor(finalParams);
+  }
+}
+
+/**
+ * Builder for searching quality profiles.
+ *
+ * @example
+ * ```typescript
+ * // Search for Java profiles
+ * const profiles = await client.qualityProfiles.search()
+ *   .language('java')
+ *   .defaults(true)
+ *   .execute();
+ *
+ * // Get profiles for a project
+ * const profiles = await client.qualityProfiles.search()
+ *   .project('my-project')
+ *   .execute();
+ * ```
+ */
+export class SearchBuilder extends BaseBuilder<SearchRequest, SearchResponse> {
+  /**
+   * Return only default profiles.
+   */
+  defaults = ParameterHelpers.createBooleanMethod<typeof this>('defaults');
+
+  /**
+   * Filter by language.
+   */
+  language = ParameterHelpers.createStringMethod<typeof this>('language');
+
+  /**
+   * Filter by project key.
+   */
+  project = ParameterHelpers.createStringMethod<typeof this>('project');
+
+  /**
+   * Filter by quality profile name.
+   */
+  qualityProfile = ParameterHelpers.createStringMethod<typeof this>('qualityProfile');
+
+  /**
+   * Organization key.
+   */
+  organization = ParameterHelpers.createStringMethod<typeof this>('organization');
+
+  async execute(): Promise<SearchResponse> {
+    return this.executor(this.params as SearchRequest);
+  }
+}

--- a/src/resources/quality-profiles/index.ts
+++ b/src/resources/quality-profiles/index.ts
@@ -1,0 +1,3 @@
+export type * from './types';
+export * from './builders';
+export { QualityProfilesClient } from './QualityProfilesClient';

--- a/src/resources/quality-profiles/types.ts
+++ b/src/resources/quality-profiles/types.ts
@@ -1,0 +1,475 @@
+/**
+ * Quality Profile related types
+ * @module quality-profiles/types
+ */
+
+/**
+ * Common quality profile structure
+ */
+export interface QualityProfile {
+  key: string;
+  name: string;
+  language: string;
+  languageName: string;
+  isInherited: boolean;
+  isBuiltIn: boolean;
+  activeRuleCount: number;
+  activeDeprecatedRuleCount: number;
+  isDefault: boolean;
+  parentKey?: string;
+  parentName?: string;
+  organization?: string;
+  rulesUpdatedAt?: string;
+  lastUsed?: string;
+  userUpdatedAt?: string;
+}
+
+/**
+ * Rule activation severity levels
+ */
+export type Severity = 'INFO' | 'MINOR' | 'MAJOR' | 'CRITICAL' | 'BLOCKER';
+
+/**
+ * Rule statuses
+ */
+export type RuleStatus = 'BETA' | 'DEPRECATED' | 'READY' | 'REMOVED';
+
+/**
+ * Rule types
+ */
+export type RuleType = 'CODE_SMELL' | 'BUG' | 'VULNERABILITY' | 'SECURITY_HOTSPOT';
+
+/**
+ * Activate rule request
+ */
+export interface ActivateRuleRequest {
+  key: string;
+  rule: string;
+  severity?: Severity;
+  params?: string;
+  reset?: boolean;
+}
+
+/**
+ * Bulk activate rules request
+ */
+export interface ActivateRulesRequest {
+  targetKey: string;
+  activation?: boolean;
+  /* eslint-disable-next-line @typescript-eslint/naming-convention */
+  active_severities?: string;
+  asc?: boolean;
+  /* eslint-disable-next-line @typescript-eslint/naming-convention */
+  available_since?: string;
+  cwe?: string;
+  inheritance?: string;
+  /* eslint-disable-next-line @typescript-eslint/naming-convention */
+  is_template?: boolean;
+  languages?: string;
+  owaspTop10?: string;
+  /* eslint-disable-next-line @typescript-eslint/naming-convention */
+  owaspTop10_2021?: string;
+  p?: number;
+  ps?: number;
+  q?: string;
+  qprofile?: string;
+  repositories?: string;
+  /* eslint-disable-next-line @typescript-eslint/naming-convention */
+  rule_key?: string;
+  s?: string;
+  /* eslint-disable-next-line @typescript-eslint/naming-convention */
+  sans_top25?: string;
+  severities?: string;
+  /* eslint-disable-next-line @typescript-eslint/naming-convention */
+  sonarsource_security?: string;
+  statuses?: string;
+  tags?: string;
+  targetSeverity?: Severity;
+  /* eslint-disable-next-line @typescript-eslint/naming-convention */
+  template_key?: string;
+  types?: string;
+}
+
+/**
+ * Bulk activate rules response
+ */
+export interface ActivateRulesResponse {
+  succeeded: number;
+  failed: number;
+  errors?: Array<{
+    msg: string;
+    rule: string;
+  }>;
+}
+
+/**
+ * Add project request
+ */
+export interface AddProjectRequest {
+  key?: string;
+  qualityProfile?: string;
+  language?: string;
+  project?: string;
+  projectUuid?: string;
+}
+
+/**
+ * Backup request
+ */
+export interface BackupRequest {
+  key?: string;
+  qualityProfile?: string;
+  language?: string;
+}
+
+/**
+ * Change parent request
+ */
+export interface ChangeParentRequest {
+  key?: string;
+  qualityProfile?: string;
+  language?: string;
+  parentKey?: string;
+  parentQualityProfile?: string;
+}
+
+/**
+ * Changelog request
+ */
+export interface ChangelogRequest {
+  key?: string;
+  qualityProfile?: string;
+  language?: string;
+  p?: number;
+  ps?: number;
+  since?: string;
+  to?: string;
+}
+
+/**
+ * Changelog entry
+ */
+export interface ChangelogEntry {
+  date: string;
+  authorLogin?: string;
+  authorName?: string;
+  action: string;
+  ruleKey: string;
+  ruleName: string;
+  params?: Record<string, string>;
+  severity?: Severity;
+}
+
+/**
+ * Changelog response
+ */
+export interface ChangelogResponse {
+  events: ChangelogEntry[];
+  paging: {
+    pageIndex: number;
+    pageSize: number;
+    total: number;
+  };
+}
+
+/**
+ * Compare request
+ */
+export interface CompareRequest {
+  leftKey?: string;
+  leftQualityProfile?: string;
+  rightKey?: string;
+  rightQualityProfile?: string;
+}
+
+/**
+ * Rule comparison
+ */
+export interface RuleComparison {
+  key: string;
+  name: string;
+  pluginKey?: string;
+  pluginName?: string;
+  languageKey?: string;
+  languageName?: string;
+  left?: {
+    severity: Severity;
+    params?: Record<string, string>;
+  };
+  right?: {
+    severity: Severity;
+    params?: Record<string, string>;
+  };
+}
+
+/**
+ * Compare response
+ */
+export interface CompareResponse {
+  left: {
+    key: string;
+    name: string;
+  };
+  right: {
+    key: string;
+    name: string;
+  };
+  inLeft: RuleComparison[];
+  inRight: RuleComparison[];
+  modified: RuleComparison[];
+  same: RuleComparison[];
+}
+
+/**
+ * Copy request
+ */
+export interface CopyRequest {
+  fromKey?: string;
+  from?: string;
+  language?: string;
+  toName: string;
+}
+
+/**
+ * Copy response
+ */
+export interface CopyResponse {
+  key: string;
+  name: string;
+  language: string;
+  languageName: string;
+  isInherited: boolean;
+  parentKey?: string;
+}
+
+/**
+ * Create request
+ */
+export interface CreateRequest {
+  name: string;
+  language: string;
+}
+
+/**
+ * Create response
+ */
+export interface CreateResponse {
+  profile: QualityProfile;
+  warnings?: string[];
+}
+
+/**
+ * Deactivate rule request
+ */
+export interface DeactivateRuleRequest {
+  key: string;
+  rule: string;
+}
+
+/**
+ * Deactivate rules request
+ */
+export type DeactivateRulesRequest = ActivateRulesRequest;
+
+/**
+ * Deactivate rules response
+ */
+export type DeactivateRulesResponse = ActivateRulesResponse;
+
+/**
+ * Delete request
+ */
+export interface DeleteRequest {
+  key?: string;
+  qualityProfile?: string;
+  language?: string;
+}
+
+/**
+ * Export request
+ */
+export interface ExportRequest {
+  key?: string;
+  qualityProfile?: string;
+  language?: string;
+  exporterKey?: string;
+}
+
+/**
+ * Exporter information
+ */
+export interface Exporter {
+  key: string;
+  name: string;
+  languages: string[];
+}
+
+/**
+ * Exporters response (deprecated)
+ */
+export interface ExportersResponse {
+  exporters: Exporter[];
+}
+
+/**
+ * Importer information
+ */
+export interface Importer {
+  key: string;
+  name: string;
+  languages: string[];
+}
+
+/**
+ * Importers response (deprecated)
+ */
+export interface ImportersResponse {
+  importers: Importer[];
+}
+
+/**
+ * Inheritance request
+ */
+export interface InheritanceRequest {
+  key?: string;
+  qualityProfile?: string;
+  language?: string;
+}
+
+/**
+ * Profile inheritance information
+ */
+export interface ProfileInheritance {
+  key: string;
+  name: string;
+  activeRuleCount: number;
+  overridingRuleCount?: number;
+  isBuiltIn: boolean;
+}
+
+/**
+ * Inheritance response
+ */
+export interface InheritanceResponse {
+  profile: QualityProfile;
+  ancestors: ProfileInheritance[];
+  children: ProfileInheritance[];
+}
+
+/**
+ * Projects request
+ */
+export interface ProjectsRequest {
+  key: string;
+  p?: number;
+  ps?: number;
+  q?: string;
+  selected?: 'all' | 'selected' | 'deselected';
+}
+
+/**
+ * Project association
+ */
+export interface ProjectAssociation {
+  id: string;
+  key: string;
+  name: string;
+  selected: boolean;
+}
+
+/**
+ * Projects response
+ */
+export interface ProjectsResponse {
+  results: ProjectAssociation[];
+  paging: {
+    pageIndex: number;
+    pageSize: number;
+    total: number;
+  };
+}
+
+/**
+ * Remove project request
+ */
+export interface RemoveProjectRequest {
+  key?: string;
+  qualityProfile?: string;
+  language?: string;
+  project?: string;
+  projectUuid?: string;
+}
+
+/**
+ * Rename request
+ */
+export interface RenameRequest {
+  key: string;
+  name: string;
+}
+
+/**
+ * Restore request
+ */
+export interface RestoreRequest {
+  backup: string;
+  organization: string;
+}
+
+/**
+ * Restore response
+ */
+export interface RestoreResponse {
+  profile: QualityProfile;
+  ruleSuccesses: number;
+  ruleFailures: number;
+}
+
+/**
+ * Search request
+ */
+export interface SearchRequest {
+  defaults?: boolean;
+  language?: string;
+  project?: string;
+  qualityProfile?: string;
+  organization?: string;
+}
+
+/**
+ * Search response
+ */
+export interface SearchResponse {
+  profiles: QualityProfile[];
+  actions?: {
+    create?: boolean;
+  };
+}
+
+/**
+ * Set default request
+ */
+export interface SetDefaultRequest {
+  key?: string;
+  qualityProfile?: string;
+  language?: string;
+}
+
+/**
+ * Common paginated request parameters
+ */
+export interface PaginatedRequest {
+  p?: number;
+  ps?: number;
+}
+
+/**
+ * Common paginated response structure
+ */
+export interface PaginatedResponse {
+  paging: {
+    pageIndex: number;
+    pageSize: number;
+    total: number;
+  };
+}


### PR DESCRIPTION
## Summary
Implements comprehensive client for the SonarQube Quality Profiles API with all 23 endpoints including rule activation/deactivation, profile management, inheritance, and project associations.

## Features
- **Complete API Coverage**: All 23 quality profiles endpoints implemented
- **Builder Pattern**: 5 specialized builders for complex operations (ActivateRules, DeactivateRules, Changelog, Projects, Search)
- **Type Safety**: Full TypeScript support with comprehensive type definitions
- **Async Pagination**: Support for iterating through paginated results
- **Error Handling**: Proper error types and validation
- **Response Types**: Handles both JSON and XML responses (backup/export)

## Endpoints Implemented
### Profile Management
- `activateRule()` - Activate a rule on a quality profile
- `activateRules()` - Bulk-activate rules with advanced filtering
- `deactivateRule()` - Deactivate a rule from a quality profile  
- `deactivateRules()` - Bulk-deactivate rules with filtering
- `create()` - Create new quality profiles
- `copy()` - Copy existing profiles
- `delete()` - Delete profiles and descendants
- `rename()` - Rename quality profiles
- `setDefault()` - Set default profile for a language

### Profile Discovery & Analysis
- `search()` - Search profiles with filtering options
- `compare()` - Compare two profiles to see differences
- `changelog()` - Get profile change history with pagination
- `inheritance()` - View profile inheritance hierarchy

### Import/Export
- `backup()` - Export profile as XML backup
- `restore()` - Restore profile from XML backup
- `export()` - Export using various format exporters
- `exporters()` - List available export formats (deprecated)
- `importers()` - List available import formats (deprecated)

### Project Association
- `addProject()` - Associate projects with profiles
- `removeProject()` - Remove project associations
- `projects()` - List/search project associations with pagination
- `projectsAll()` - Convenience method to iterate all projects

### Profile Hierarchy
- `changeParent()` - Modify profile inheritance relationships

## Test Coverage
- **772 total tests** passing
- Comprehensive unit tests for all endpoints
- Builder pattern validation tests
- Error handling scenarios
- MSW-based HTTP mocking

🤖 Generated with [Claude Code](https://claude.ai/code)