### PR TITLE
docs: Clarify user_properties API removal status

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The following APIs or actions are marked as deprecated in the SonarQube Web API:
 | **api/qualityprofiles** | `export`, `exporters`, `importers` | 18 March, 2025 | Profile export/import being redesigned |
 | **api/qualityprofiles** | `restore_built_in` | 6.4 | Built-in profiles restored automatically |
 | **api/timemachine** | `index` | 6.3 | Entire API is deprecated, use `api/measures/history` |
-| **api/user_properties** | `index` | 6.3 | User properties management deprecated |
+| **api/user_properties** | `index` | 6.3 | Removed since 6.3, use `api/favorites` and `api/notifications` instead |
 | **api/users** | `search` | 10 February, 2025 | Use newer user search endpoints |
 
 **Note**: This library may still provide support for some deprecated APIs for backward compatibility, but we recommend migrating to newer alternatives where available.


### PR DESCRIPTION
## Summary
- Updated the deprecated APIs documentation to clarify that `api/user_properties` has been **removed** (not just deprecated) since SonarQube 6.3
- Added guidance to use the existing `api/favorites` and `api/notifications` endpoints as alternatives

## Context
The user requested support for the `api/user_properties` resource. Upon investigation, the SonarQube API specification shows this endpoint was removed in version 6.3, with the recommendation to use `api/favorites` and `api/notifications` instead. Both alternative APIs are already implemented in this library.

## Changes
- Updated README.md deprecated APIs table to clarify the removal status and provide alternative endpoints

## Test plan
- [x] Documentation change only - no code changes required
- [x] Verified that the alternative APIs (`favorites` and `notifications`) are already implemented
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)