### PR TITLE
feat: Add support for SonarQube Rules API

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ We're continuously adding support for more SonarQube/SonarCloud APIs. Here's wha
 | **Properties** | `api/properties` | ❌ Not implemented | Both | Property management (deprecated) |
 | **Quality Gates** | `api/qualitygates` | ✅ Implemented | Both | Quality gate management |
 | **Quality Profiles** | `api/qualityprofiles` | ✅ Implemented | Both | Quality profile management |
-| **Rules** | `api/rules` | ❌ Not implemented | Both | Coding rule management |
+| **Rules** | `api/rules` | ✅ Implemented | Both | Coding rule management |
 | **Settings** | `api/settings` | ✅ Implemented | Both | Global and project settings |
 | **Sources** | `api/sources` | ✅ Implemented | Both | Source code access |
 | **System** | `api/system` | ✅ Implemented | SonarQube only | System information and health |
@@ -351,6 +351,72 @@ for await (const language of client.languages.listAll()) {
 // Filter while iterating
 for await (const language of client.languages.listAll({ q: 'python' })) {
   console.log(`Found Python-related language: ${language.name}`);
+}
+```
+
+### 📜 Working with Rules
+
+```typescript
+// List available rule repositories
+const repositories = await client.rules.listRepositories();
+console.log('Available rule repositories:', repositories.repositories);
+
+// Filter repositories by language
+const javaRepos = await client.rules.listRepositories({
+  language: 'java'
+});
+
+// Search for rules with advanced filtering
+const securityRules = await client.rules.search()
+  .withTypes(['VULNERABILITY', 'SECURITY_HOTSPOT'])
+  .withSeverities(['CRITICAL', 'BLOCKER'])
+  .withTags(['security', 'owasp'])
+  .withLanguages(['java', 'javascript'])
+  .includeExternal()
+  .execute();
+
+// Search for rules in a specific quality profile
+const profileRules = await client.rules.search()
+  .inQualityProfile('java-sonar-way-12345')
+  .withActivation(true)
+  .execute();
+
+// Get detailed information about a specific rule
+const ruleDetails = await client.rules.show({
+  key: 'java:S1234',
+  organization: 'my-org',
+  actives: true  // Include activation details
+});
+
+// List all available rule tags
+const tags = await client.rules.listTags({
+  organization: 'my-org',
+  q: 'security'  // Filter tags containing 'security'
+});
+
+// Update a custom rule
+await client.rules.update({
+  key: 'java:S1234',
+  organization: 'my-org',
+  name: 'Updated Rule Name',
+  severity: 'CRITICAL',
+  tags: 'security,owasp-a1',
+  markdown_description: 'Updated rule description in markdown'
+});
+
+// Search with Clean Code attributes (new in SonarQube 10+)
+const cleanCodeRules = await client.rules.search()
+  .withCleanCodeAttributeCategories(['INTENTIONAL', 'CONSISTENT'])
+  .withImpactSeverities(['HIGH', 'MEDIUM'])
+  .withImpactSoftwareQualities(['SECURITY', 'RELIABILITY'])
+  .execute();
+
+// Iterate through all rules with pagination
+for await (const rule of client.rules.search()
+  .withLanguages(['typescript'])
+  .withTypes(['BUG'])
+  .all()) {
+  console.log(`Rule: ${rule.key} - ${rule.name} (${rule.severity})`);
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { ProjectBranchesClient } from './resources/project-branches';
 import { ProjectPullRequestsClient } from './resources/project-pull-requests';
 import { ProjectTagsClient } from './resources/project-tags';
 import { QualityProfilesClient } from './resources/quality-profiles';
+import { RulesClient } from './resources/rules';
 import { SettingsClient } from './resources/settings';
 
 interface ProjectsResponse {
@@ -88,6 +89,8 @@ export class SonarQubeClient {
   public readonly qualityGates: QualityGatesClient;
   /** Quality Profiles API */
   public readonly qualityProfiles: QualityProfilesClient;
+  /** Rules API */
+  public readonly rules: RulesClient;
   /** Sources API */
   public readonly sources: SourcesClient;
   /** System API - **Note**: Only available in SonarQube, not in SonarCloud */
@@ -134,6 +137,7 @@ export class SonarQubeClient {
     this.measures = new MeasuresClient(this.baseUrl, this.token, this.organization);
     this.qualityGates = new QualityGatesClient(this.baseUrl, this.token, this.organization);
     this.qualityProfiles = new QualityProfilesClient(this.baseUrl, this.token, this.organization);
+    this.rules = new RulesClient(this.baseUrl, this.token, this.organization);
     this.sources = new SourcesClient(this.baseUrl, this.token, this.organization);
     this.system = new SystemClient(this.baseUrl, this.token, this.organization);
     this.projectTags = new ProjectTagsClient(this.baseUrl, this.token, this.organization);
@@ -613,6 +617,35 @@ export type {
   SearchResponse as SearchQualityProfilesResponse,
   SetDefaultRequest as SetDefaultQualityProfileRequest,
 } from './resources/quality-profiles/types';
+
+// Re-export types from rules
+export type {
+  Rule,
+  RuleRepository,
+  RuleParameter,
+  RuleDescriptionSection,
+  RuleImpact,
+  RuleActivation,
+  RuleSeverity,
+  RuleStatus as RuleStatusType,
+  RuleType as RuleTypeEnum,
+  CleanCodeAttributeCategory as RuleCleanCodeAttributeCategory,
+  SoftwareQuality,
+  ImpactSeverity as RuleImpactSeverity,
+  RuleInheritance,
+  RemediationFunctionType,
+  FacetMode as RuleFacetMode,
+  ListRepositoriesRequest,
+  ListRepositoriesResponse,
+  SearchRulesRequest,
+  SearchRulesResponse,
+  ShowRuleRequest,
+  ShowRuleResponse,
+  ListTagsRequest as ListRuleTagsRequest,
+  ListTagsResponse as ListRuleTagsResponse,
+  UpdateRuleRequest,
+  UpdateRuleResponse,
+} from './resources/rules/types';
 
 // Re-export types from settings
 export type {

--- a/src/resources/rules/RulesClient.ts
+++ b/src/resources/rules/RulesClient.ts
@@ -169,8 +169,8 @@ export class RulesClient extends BaseClient {
     // Add parameters to search params
     Object.entries(params).forEach(([key, value]) => {
       if (value !== undefined && value !== null) {
-        // Handle special case for owaspTop10-2021
-        const apiKey = key === 'owaspTop10-2021' ? 'owaspTop10-2021' : key;
+        // Assign key directly to apiKey
+        const apiKey = key;
 
         if (arrayParams.includes(key as keyof SearchRulesRequest) && Array.isArray(value)) {
           if (value.length > 0) {

--- a/src/resources/rules/RulesClient.ts
+++ b/src/resources/rules/RulesClient.ts
@@ -1,0 +1,189 @@
+import { BaseClient } from '../../core/BaseClient';
+import { SearchRulesBuilder } from './builders';
+import type {
+  ListRepositoriesRequest,
+  ListRepositoriesResponse,
+  SearchRulesRequest,
+  SearchRulesResponse,
+  ShowRuleRequest,
+  ShowRuleResponse,
+  ListTagsRequest,
+  ListTagsResponse,
+  UpdateRuleRequest,
+  UpdateRuleResponse,
+} from './types';
+
+/**
+ * Client for managing SonarQube rules
+ */
+export class RulesClient extends BaseClient {
+  /**
+   * List available rule repositories
+   * @param params - Request parameters
+   * @returns List of rule repositories
+   * @throws {Error} If the request fails
+   */
+  async listRepositories(params?: ListRepositoriesRequest): Promise<ListRepositoriesResponse> {
+    const searchParams = new URLSearchParams();
+
+    if (params?.language !== undefined && params.language.length > 0) {
+      searchParams.append('language', params.language);
+    }
+    if (params?.q !== undefined && params.q.length > 0) {
+      searchParams.append('q', params.q);
+    }
+
+    const query = searchParams.toString();
+    const url = query ? `/api/rules/repositories?${query}` : '/api/rules/repositories';
+
+    return this.request<ListRepositoriesResponse>(url);
+  }
+
+  /**
+   * Search for rules with advanced filtering and pagination support
+   * @returns Builder for constructing complex search queries
+   */
+  search(): SearchRulesBuilder {
+    return new SearchRulesBuilder(async (params: SearchRulesRequest) =>
+      this.searchExecutor(params)
+    );
+  }
+
+  /**
+   * Get detailed information about a rule
+   * @param params - Request parameters
+   * @returns Detailed rule information
+   * @throws {Error} If the request fails
+   */
+  async show(params: ShowRuleRequest): Promise<ShowRuleResponse> {
+    const searchParams = new URLSearchParams({
+      key: params.key,
+      organization: params.organization,
+    });
+
+    if (params.actives !== undefined) {
+      searchParams.append('actives', params.actives.toString());
+    }
+
+    return this.request<ShowRuleResponse>(`/api/rules/show?${searchParams.toString()}`);
+  }
+
+  /**
+   * List rule tags
+   * @param params - Request parameters
+   * @returns List of rule tags
+   * @throws {Error} If the request fails
+   */
+  async listTags(params: ListTagsRequest): Promise<ListTagsResponse> {
+    const searchParams = new URLSearchParams({
+      organization: params.organization,
+    });
+
+    if (params.ps !== undefined) {
+      searchParams.append('ps', params.ps.toString());
+    }
+    if (params.q !== undefined && params.q.length > 0) {
+      searchParams.append('q', params.q);
+    }
+
+    return this.request<ListTagsResponse>(`/api/rules/tags?${searchParams.toString()}`);
+  }
+
+  /**
+   * Update an existing rule
+   * @param params - Request parameters
+   * @returns The updated rule
+   * @throws {Error} If the request fails
+   * @requires Administer Quality Profiles permission
+   */
+  async update(params: UpdateRuleRequest): Promise<UpdateRuleResponse> {
+    const body: Record<string, string> = {
+      key: params.key,
+      organization: params.organization,
+    };
+
+    if (params.markdown_description !== undefined) {
+      body['markdown_description'] = params.markdown_description;
+    }
+    if (params.markdown_note !== undefined) {
+      body['markdown_note'] = params.markdown_note;
+    }
+    if (params.name !== undefined) {
+      body['name'] = params.name;
+    }
+    if (params.params !== undefined) {
+      body['params'] = params.params;
+    }
+    if (params.remediation_fn_base_effort !== undefined) {
+      body['remediation_fn_base_effort'] = params.remediation_fn_base_effort;
+    }
+    if (params.remediation_fn_type !== undefined) {
+      body['remediation_fn_type'] = params.remediation_fn_type;
+    }
+    if (params.remediation_fy_gap_multiplier !== undefined) {
+      body['remediation_fy_gap_multiplier'] = params.remediation_fy_gap_multiplier;
+    }
+    if (params.severity !== undefined) {
+      body['severity'] = params.severity;
+    }
+    if (params.status !== undefined) {
+      body['status'] = params.status;
+    }
+    if (params.tags !== undefined) {
+      body['tags'] = params.tags;
+    }
+
+    return this.request<UpdateRuleResponse>('/api/rules/update', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  }
+
+  /**
+   * Execute search request with proper parameter handling
+   */
+  private async searchExecutor(params: SearchRulesRequest): Promise<SearchRulesResponse> {
+    const searchParams = new URLSearchParams();
+
+    // Handle array parameters by joining with commas
+    const arrayParams: Array<keyof SearchRulesRequest> = [
+      'active_severities',
+      'cleanCodeAttributeCategories',
+      'cwe',
+      'f',
+      'facets',
+      'impactSeverities',
+      'impactSoftwareQualities',
+      'inheritance',
+      'languages',
+      'owaspTop10',
+      'repositories',
+      'rule_keys',
+      'severities',
+      'sonarsourceSecurity',
+      'statuses',
+      'tags',
+      'types',
+    ];
+
+    // Add parameters to search params
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        // Handle special case for owaspTop10-2021
+        const apiKey = key === 'owaspTop10-2021' ? 'owaspTop10-2021' : key;
+
+        if (arrayParams.includes(key as keyof SearchRulesRequest) && Array.isArray(value)) {
+          if (value.length > 0) {
+            searchParams.append(apiKey, value.join(','));
+          }
+        } else if (typeof value === 'boolean') {
+          searchParams.append(apiKey, value.toString());
+        } else if (typeof value === 'number' || typeof value === 'string') {
+          searchParams.append(apiKey, value.toString());
+        }
+      }
+    });
+
+    return this.request<SearchRulesResponse>(`/api/rules/search?${searchParams.toString()}`);
+  }
+}

--- a/src/resources/rules/__tests__/RulesClient.test.ts
+++ b/src/resources/rules/__tests__/RulesClient.test.ts
@@ -56,6 +56,74 @@ describe('RulesClient', () => {
       const builder = client.search();
       expect(builder).toBeInstanceOf(SearchRulesBuilder);
     });
+
+    it('should execute search with various parameters', async () => {
+      const result = await client
+        .search()
+        .withLanguages(['java', 'javascript'])
+        .withSeverities(['CRITICAL', 'MAJOR'])
+        .withTypes(['BUG', 'VULNERABILITY'])
+        .withTags(['security', 'performance'])
+        .withStatuses(['READY'])
+        .withActivation(true)
+        .withActiveSeverities(['BLOCKER'])
+        .availableSince('2024-01-01')
+        .withCleanCodeAttributeCategories(['INTENTIONAL'])
+        .withCwe(['CWE-89'])
+        .withFields(['name', 'severity'])
+        .withFacets(['languages', 'repositories'])
+        .withImpactSeverities(['HIGH'])
+        .withImpactSoftwareQualities(['SECURITY'])
+        .includeExternal(true)
+        .withInheritance(['INHERITED'])
+        .isTemplate(false)
+        .inOrganization('my-org')
+        .withOwaspTop10(['a1'])
+        .withOwaspTop10v2021(['a01'])
+        .withQuery('injection')
+        .inQualityProfile('profile-key')
+        .withRepositories(['java'])
+        .withRuleKey('java:S1234')
+        .withRuleKeys(['java:S1234', 'java:S5678'])
+        .sortBy('name', false)
+        .withSonarSourceSecurity(['sql-injection'])
+        .withTemplateKey('java:S001')
+        .pageSize(50)
+        .page(2)
+        .execute();
+
+      // Verify the response structure
+      expect(result).toHaveProperty('total');
+      expect(result).toHaveProperty('p');
+      expect(result).toHaveProperty('ps');
+      expect(result).toHaveProperty('rules');
+      expect(Array.isArray(result.rules)).toBe(true);
+    });
+
+    it('should handle search with empty arrays', async () => {
+      const result = await client
+        .search()
+        .withLanguages([])
+        .withSeverities([])
+        .withTypes([])
+        .execute();
+
+      // Should still return a valid response even with empty filters
+      expect(result).toHaveProperty('total');
+      expect(result).toHaveProperty('rules');
+      expect(Array.isArray(result.rules)).toBe(true);
+    });
+
+    it('should handle search with minimal parameters', async () => {
+      const result = await client.search().execute();
+
+      // Should return the expected response structure
+      expect(result).toHaveProperty('total');
+      expect(result).toHaveProperty('p');
+      expect(result).toHaveProperty('ps');
+      expect(result).toHaveProperty('rules');
+      expect(Array.isArray(result.rules)).toBe(true);
+    });
   });
 
   describe('show', () => {
@@ -179,6 +247,28 @@ describe('RulesClient', () => {
       expect(result.rule.remFn).toBe('LINEAR');
       expect(result.rule.remFnBaseEffort).toBe('5min');
       expect(result.rule.remFnGapMultiplier).toBe('10min');
+    });
+
+    it('should update rule with params', async () => {
+      const result = await client.update({
+        key: 'java:S1234',
+        organization: 'my-org',
+        params: 'max=10;format=text',
+      });
+
+      expect(result.rule).toBeDefined();
+      expect(result.rule.key).toBe('java:S1234');
+    });
+
+    it('should update rule status', async () => {
+      const result = await client.update({
+        key: 'java:S1234',
+        organization: 'my-org',
+        status: 'DEPRECATED',
+      });
+
+      expect(result.rule).toBeDefined();
+      expect(result.rule.key).toBe('java:S1234');
     });
 
     it('should throw on authorization error', async () => {

--- a/src/resources/rules/__tests__/RulesClient.test.ts
+++ b/src/resources/rules/__tests__/RulesClient.test.ts
@@ -1,0 +1,203 @@
+import { RulesClient } from '../RulesClient';
+import { SearchRulesBuilder } from '../builders';
+import { server } from '../../../test-utils/msw/server';
+import { http, HttpResponse } from 'msw';
+
+describe('RulesClient', () => {
+  const baseUrl = 'https://sonarqube.example.com';
+  const token = 'test-token';
+  let client: RulesClient;
+
+  beforeEach(() => {
+    client = new RulesClient(baseUrl, token);
+  });
+
+  describe('listRepositories', () => {
+    it('should list all rule repositories', async () => {
+      const result = await client.listRepositories();
+
+      expect(result.repositories).toHaveLength(4);
+      expect(result.repositories[0]).toEqual({
+        key: 'java',
+        name: 'SonarQube',
+        language: 'java',
+      });
+    });
+
+    it('should filter repositories by language', async () => {
+      const result = await client.listRepositories({ language: 'java' });
+
+      expect(result.repositories).toHaveLength(2);
+      expect(result.repositories[0].language).toBe('java');
+      expect(result.repositories[1].language).toBe('java');
+    });
+
+    it('should filter repositories by query', async () => {
+      const result = await client.listRepositories({ q: 'squid' });
+
+      expect(result.repositories).toHaveLength(1);
+      expect(result.repositories[0].key).toContain('squid');
+    });
+
+    it('should handle empty results', async () => {
+      server.use(
+        http.get('*/api/rules/repositories', () => {
+          return HttpResponse.json({ repositories: [] });
+        })
+      );
+
+      const result = await client.listRepositories({ language: 'unknown' });
+      expect(result.repositories).toHaveLength(0);
+    });
+  });
+
+  describe('search', () => {
+    it('should return a SearchRulesBuilder instance', () => {
+      const builder = client.search();
+      expect(builder).toBeInstanceOf(SearchRulesBuilder);
+    });
+  });
+
+  describe('show', () => {
+    it('should get detailed rule information', async () => {
+      const result = await client.show({
+        key: 'java:S1234',
+        organization: 'my-org',
+      });
+
+      expect(result.rule.key).toBe('java:S1234');
+      expect(result.rule.name).toBe('Rule Name');
+      expect(result.rule.severity).toBe('MAJOR');
+    });
+
+    it('should include activations when requested', async () => {
+      const result = await client.show({
+        key: 'java:S1234',
+        organization: 'my-org',
+        actives: true,
+      });
+
+      expect(result.rule.key).toBe('java:S1234');
+      expect(result.actives).toBeDefined();
+      expect(result.actives).toHaveLength(1);
+    });
+
+    it('should throw on not found error', async () => {
+      server.use(
+        http.get('*/api/rules/show', () => {
+          return new HttpResponse(JSON.stringify({ errors: [{ msg: 'Rule not found' }] }), {
+            status: 404,
+          });
+        })
+      );
+
+      await expect(
+        client.show({
+          key: 'unknown:rule',
+          organization: 'my-org',
+        })
+      ).rejects.toThrow('Not Found');
+    });
+  });
+
+  describe('listTags', () => {
+    it('should list all rule tags', async () => {
+      const result = await client.listTags({
+        organization: 'my-org',
+      });
+
+      expect(result.tags).toEqual(['security', 'java8', 'performance', 'sql', 'injection']);
+    });
+
+    it('should filter tags by query', async () => {
+      const result = await client.listTags({
+        organization: 'my-org',
+        q: 'sec',
+      });
+
+      expect(result.tags).toEqual(['security']);
+    });
+
+    it('should respect page size parameter', async () => {
+      const result = await client.listTags({
+        organization: 'my-org',
+        ps: 2,
+      });
+
+      expect(result.tags).toHaveLength(2);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a rule successfully', async () => {
+      const result = await client.update({
+        key: 'java:S1234',
+        organization: 'my-org',
+        name: 'Updated Rule Name',
+        severity: 'CRITICAL',
+        tags: 'security,java8',
+      });
+
+      expect(result.rule.key).toBe('java:S1234');
+      expect(result.rule.name).toBe('Updated Rule Name');
+      expect(result.rule.severity).toBe('CRITICAL');
+      expect(result.rule.tags).toEqual(['security', 'java8']);
+    });
+
+    it('should update rule description', async () => {
+      const result = await client.update({
+        key: 'java:S1234',
+        organization: 'my-org',
+        markdown_description: 'Updated description',
+      });
+
+      expect(result.rule.key).toBe('java:S1234');
+      expect(result.rule.mdDesc).toBe('Updated description');
+    });
+
+    it('should update rule note', async () => {
+      const result = await client.update({
+        key: 'java:S1234',
+        organization: 'my-org',
+        markdown_note: 'This is a note',
+      });
+
+      expect(result.rule.key).toBe('java:S1234');
+      expect(result.rule.mdNote).toBe('This is a note');
+    });
+
+    it('should update remediation function', async () => {
+      const result = await client.update({
+        key: 'java:S1234',
+        organization: 'my-org',
+        remediation_fn_type: 'LINEAR',
+        remediation_fn_base_effort: '5min',
+        remediation_fy_gap_multiplier: '10min',
+      });
+
+      expect(result.rule.key).toBe('java:S1234');
+      expect(result.rule.remFn).toBe('LINEAR');
+      expect(result.rule.remFnBaseEffort).toBe('5min');
+      expect(result.rule.remFnGapMultiplier).toBe('10min');
+    });
+
+    it('should throw on authorization error', async () => {
+      server.use(
+        http.post('*/api/rules/update', () => {
+          return new HttpResponse(
+            JSON.stringify({ errors: [{ msg: 'Insufficient privileges' }] }),
+            { status: 403 }
+          );
+        })
+      );
+
+      await expect(
+        client.update({
+          key: 'java:S1234',
+          organization: 'my-org',
+          name: 'Will fail',
+        })
+      ).rejects.toThrow('Forbidden');
+    });
+  });
+});

--- a/src/resources/rules/__tests__/builders.test.ts
+++ b/src/resources/rules/__tests__/builders.test.ts
@@ -1,0 +1,289 @@
+import { SearchRulesBuilder } from '../builders';
+import type { SearchRulesRequest, SearchRulesResponse } from '../types';
+
+describe('SearchRulesBuilder', () => {
+  let builder: SearchRulesBuilder;
+  let mockExecutor: jest.Mock<Promise<SearchRulesResponse>, [SearchRulesRequest]>;
+
+  beforeEach(() => {
+    mockExecutor = jest.fn<Promise<SearchRulesResponse>, [SearchRulesRequest]>().mockResolvedValue({
+      total: 0,
+      p: 1,
+      ps: 100,
+      rules: [],
+    });
+    builder = new SearchRulesBuilder(mockExecutor);
+  });
+
+  describe('filter methods', () => {
+    it('should set activation filter', () => {
+      builder.withActivation(true);
+      expect(builder['params'].activation).toBe(true);
+    });
+
+    it('should set active severities filter', () => {
+      builder.withActiveSeverities(['CRITICAL', 'BLOCKER']);
+      expect(builder['params'].active_severities).toEqual(['CRITICAL', 'BLOCKER']);
+    });
+
+    it('should set available since date filter', () => {
+      builder.availableSince('2024-01-01');
+      expect(builder['params'].available_since).toBe('2024-01-01');
+    });
+
+    it('should set clean code attribute categories filter', () => {
+      builder.withCleanCodeAttributeCategories(['INTENTIONAL', 'CONSISTENT']);
+      expect(builder['params'].cleanCodeAttributeCategories).toEqual(['INTENTIONAL', 'CONSISTENT']);
+    });
+
+    it('should set CWE filter', () => {
+      builder.withCwe(['CWE-89', 'CWE-79']);
+      expect(builder['params'].cwe).toEqual(['CWE-89', 'CWE-79']);
+    });
+
+    it('should set fields to return', () => {
+      builder.withFields(['name', 'severity', 'tags']);
+      expect(builder['params'].f).toEqual(['name', 'severity', 'tags']);
+    });
+
+    it('should set facets', () => {
+      builder.withFacets(['languages', 'repositories']);
+      expect(builder['params'].facets).toEqual(['languages', 'repositories']);
+    });
+
+    it('should set impact severities filter', () => {
+      builder.withImpactSeverities(['HIGH', 'MEDIUM']);
+      expect(builder['params'].impactSeverities).toEqual(['HIGH', 'MEDIUM']);
+    });
+
+    it('should set impact software qualities filter', () => {
+      builder.withImpactSoftwareQualities(['SECURITY', 'RELIABILITY']);
+      expect(builder['params'].impactSoftwareQualities).toEqual(['SECURITY', 'RELIABILITY']);
+    });
+
+    it('should set include external flag', () => {
+      builder.includeExternal();
+      expect(builder['params'].include_external).toBe(true);
+
+      builder.includeExternal(false);
+      expect(builder['params'].include_external).toBe(false);
+    });
+
+    it('should set inheritance filter', () => {
+      builder.withInheritance(['INHERITED', 'OVERRIDES']);
+      expect(builder['params'].inheritance).toEqual(['INHERITED', 'OVERRIDES']);
+    });
+
+    it('should set template filter', () => {
+      builder.isTemplate(true);
+      expect(builder['params'].is_template).toBe(true);
+    });
+
+    it('should set languages filter', () => {
+      builder.withLanguages(['java', 'javascript']);
+      expect(builder['params'].languages).toEqual(['java', 'javascript']);
+    });
+
+    it('should set organization filter', () => {
+      builder.inOrganization('my-org');
+      expect(builder['params'].organization).toBe('my-org');
+    });
+
+    it('should set OWASP Top 10 filter', () => {
+      builder.withOwaspTop10(['a1', 'a2']);
+      expect(builder['params'].owaspTop10).toEqual(['a1', 'a2']);
+    });
+
+    it('should set OWASP Top 10 2021 filter', () => {
+      builder.withOwaspTop10v2021(['a1', 'a2']);
+      expect(builder['params']['owaspTop10-2021']).toEqual(['a1', 'a2']);
+    });
+
+    it('should set query string', () => {
+      builder.withQuery('xpath');
+      expect(builder['params'].q).toBe('xpath');
+    });
+
+    it('should set quality profile filter', () => {
+      builder.inQualityProfile('profile-key');
+      expect(builder['params'].qprofile).toBe('profile-key');
+    });
+
+    it('should set repositories filter', () => {
+      builder.withRepositories(['java', 'javascript']);
+      expect(builder['params'].repositories).toEqual(['java', 'javascript']);
+    });
+
+    it('should set single rule key filter', () => {
+      builder.withRuleKey('java:S1234');
+      expect(builder['params'].rule_key).toBe('java:S1234');
+    });
+
+    it('should set multiple rule keys filter', () => {
+      builder.withRuleKeys(['java:S1234', 'java:S5678']);
+      expect(builder['params'].rule_keys).toEqual(['java:S1234', 'java:S5678']);
+    });
+
+    it('should set sort parameters', () => {
+      builder.sortBy('name');
+      expect(builder['params'].s).toBe('name');
+      expect(builder['params'].asc).toBe(true);
+
+      builder.sortBy('updatedAt', false);
+      expect(builder['params'].s).toBe('updatedAt');
+      expect(builder['params'].asc).toBe(false);
+    });
+
+    it('should set severities filter', () => {
+      builder.withSeverities(['MAJOR', 'CRITICAL']);
+      expect(builder['params'].severities).toEqual(['MAJOR', 'CRITICAL']);
+    });
+
+    it('should set SonarSource security filter', () => {
+      builder.withSonarSourceSecurity(['sql-injection', 'xss']);
+      expect(builder['params'].sonarsourceSecurity).toEqual(['sql-injection', 'xss']);
+    });
+
+    it('should set statuses filter', () => {
+      builder.withStatuses(['READY', 'DEPRECATED']);
+      expect(builder['params'].statuses).toEqual(['READY', 'DEPRECATED']);
+    });
+
+    it('should set tags filter', () => {
+      builder.withTags(['security', 'java8']);
+      expect(builder['params'].tags).toEqual(['security', 'java8']);
+    });
+
+    it('should set template key filter', () => {
+      builder.withTemplateKey('java:S001');
+      expect(builder['params'].template_key).toBe('java:S001');
+    });
+
+    it('should set types filter', () => {
+      builder.withTypes(['BUG', 'VULNERABILITY']);
+      expect(builder['params'].types).toEqual(['BUG', 'VULNERABILITY']);
+    });
+  });
+
+  describe('chaining', () => {
+    it('should support method chaining', () => {
+      const result = builder
+        .withLanguages(['java'])
+        .withSeverities(['MAJOR'])
+        .withTypes(['BUG'])
+        .withTags(['security'])
+        .inOrganization('my-org')
+        .pageSize(50);
+
+      expect(result).toBe(builder);
+      expect(builder['params']).toMatchObject({
+        languages: ['java'],
+        severities: ['MAJOR'],
+        types: ['BUG'],
+        tags: ['security'],
+        organization: 'my-org',
+        ps: 50,
+      });
+    });
+  });
+
+  describe('execute', () => {
+    it('should call executor with params', async () => {
+      builder.withLanguages(['java']).withSeverities(['CRITICAL']).pageSize(50);
+
+      await builder.execute();
+
+      expect(mockExecutor).toHaveBeenCalledWith({
+        languages: ['java'],
+        severities: ['CRITICAL'],
+        ps: 50,
+      });
+    });
+  });
+
+  describe('pagination', () => {
+    it('should return items from response', () => {
+      const response: SearchRulesResponse = {
+        total: 2,
+        p: 1,
+        ps: 100,
+        rules: [
+          {
+            key: 'rule1',
+            repo: 'java',
+            name: 'Rule 1',
+            severity: 'MAJOR',
+            status: 'READY',
+            type: 'BUG',
+          },
+          {
+            key: 'rule2',
+            repo: 'java',
+            name: 'Rule 2',
+            severity: 'CRITICAL',
+            status: 'READY',
+            type: 'VULNERABILITY',
+          },
+        ],
+      };
+
+      const items = builder['getItems'](response);
+      expect(items).toEqual(response.rules);
+    });
+
+    it('should support async iteration', async () => {
+      const mockResponses: SearchRulesResponse[] = [
+        {
+          total: 150,
+          p: 1,
+          ps: 100,
+          rules: Array(100)
+            .fill(null)
+            .map((_, i) => ({
+              key: `rule${String(i)}`,
+              repo: 'java',
+              name: `Rule ${String(i)}`,
+              severity: 'MAJOR' as const,
+              status: 'READY' as const,
+              type: 'BUG' as const,
+            })),
+          paging: {
+            pageIndex: 1,
+            pageSize: 100,
+            total: 150,
+          },
+        },
+        {
+          total: 150,
+          p: 2,
+          ps: 100,
+          rules: Array(50)
+            .fill(null)
+            .map((_, i) => ({
+              key: `rule${String(100 + i)}`,
+              repo: 'java',
+              name: `Rule ${String(100 + i)}`,
+              severity: 'MAJOR' as const,
+              status: 'READY' as const,
+              type: 'BUG' as const,
+            })),
+          paging: {
+            pageIndex: 2,
+            pageSize: 100,
+            total: 150,
+          },
+        },
+      ];
+
+      mockExecutor.mockResolvedValueOnce(mockResponses[0]).mockResolvedValueOnce(mockResponses[1]);
+
+      const allRules = [];
+      for await (const rule of builder.all()) {
+        allRules.push(rule);
+      }
+
+      expect(allRules).toHaveLength(150);
+      expect(mockExecutor).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/resources/rules/builders.ts
+++ b/src/resources/rules/builders.ts
@@ -1,0 +1,233 @@
+import { PaginatedBuilder } from '../../core/builders';
+import type {
+  SearchRulesRequest,
+  SearchRulesResponse,
+  Rule,
+  RuleSeverity,
+  RuleStatus,
+  RuleType,
+  CleanCodeAttributeCategory,
+  SoftwareQuality,
+  ImpactSeverity,
+  RuleInheritance,
+} from './types';
+
+/**
+ * Builder for constructing complex rule search queries
+ */
+export class SearchRulesBuilder extends PaginatedBuilder<
+  SearchRulesRequest,
+  SearchRulesResponse,
+  Rule
+> {
+  /**
+   * Filter rules that are activated or deactivated on the selected Quality profile
+   */
+  withActivation(activated: boolean): this {
+    return this.setParam('activation', activated);
+  }
+
+  /**
+   * Filter by activation severities
+   */
+  withActiveSeverities(severities: RuleSeverity[]): this {
+    return this.setParam('active_severities', severities);
+  }
+
+  /**
+   * Filter rules added since specified date (yyyy-MM-dd format)
+   */
+  availableSince(date: string): this {
+    return this.setParam('available_since', date);
+  }
+
+  /**
+   * Filter by Clean Code attribute categories
+   */
+  withCleanCodeAttributeCategories(categories: CleanCodeAttributeCategory[]): this {
+    return this.setParam('cleanCodeAttributeCategories', categories);
+  }
+
+  /**
+   * Filter by CWE identifiers
+   */
+  withCwe(cweIds: string[]): this {
+    return this.setParam('cwe', cweIds);
+  }
+
+  /**
+   * Specify fields to be returned in response
+   */
+  withFields(fields: string[]): this {
+    return this.setParam('f', fields);
+  }
+
+  /**
+   * Request facets for aggregated data
+   */
+  withFacets(facets: string[]): this {
+    return this.setParam('facets', facets);
+  }
+
+  /**
+   * Filter by impact severities
+   */
+  withImpactSeverities(severities: ImpactSeverity[]): this {
+    return this.setParam('impactSeverities', severities);
+  }
+
+  /**
+   * Filter by software quality impacts
+   */
+  withImpactSoftwareQualities(qualities: SoftwareQuality[]): this {
+    return this.setParam('impactSoftwareQualities', qualities);
+  }
+
+  /**
+   * Include external engine rules in the results
+   */
+  includeExternal(include = true): this {
+    return this.setParam('include_external', include);
+  }
+
+  /**
+   * Filter by inheritance values for a rule within a quality profile
+   */
+  withInheritance(inheritance: RuleInheritance[]): this {
+    return this.setParam('inheritance', inheritance);
+  }
+
+  /**
+   * Filter template rules
+   */
+  isTemplate(template: boolean): this {
+    return this.setParam('is_template', template);
+  }
+
+  /**
+   * Filter by programming languages
+   */
+  withLanguages(languages: string[]): this {
+    return this.setParam('languages', languages);
+  }
+
+  /**
+   * Filter by organization
+   */
+  inOrganization(organization: string): this {
+    return this.setParam('organization', organization);
+  }
+
+  /**
+   * Filter by OWASP Top 10 categories
+   */
+  withOwaspTop10(categories: string[]): this {
+    return this.setParam('owaspTop10', categories);
+  }
+
+  /**
+   * Filter by OWASP Top 10 2021 categories
+   */
+  withOwaspTop10v2021(categories: string[]): this {
+    return this.setParam('owaspTop10-2021', categories);
+  }
+
+  /**
+   * Search rules by query string
+   */
+  withQuery(query: string): this {
+    return this.setParam('q', query);
+  }
+
+  /**
+   * Filter by quality profile key
+   */
+  inQualityProfile(profileKey: string): this {
+    return this.setParam('qprofile', profileKey);
+  }
+
+  /**
+   * Filter by repositories
+   */
+  withRepositories(repositories: string[]): this {
+    return this.setParam('repositories', repositories);
+  }
+
+  /**
+   * Search for a specific rule by key
+   */
+  withRuleKey(key: string): this {
+    return this.setParam('rule_key', key);
+  }
+
+  /**
+   * Filter by multiple rule keys
+   */
+  withRuleKeys(keys: string[]): this {
+    return this.setParam('rule_keys', keys);
+  }
+
+  /**
+   * Set sorting field and order
+   */
+  sortBy(field: 'name' | 'updatedAt' | 'createdAt' | 'key', ascending = true): this {
+    this.setParam('s', field);
+    return this.setParam('asc', ascending);
+  }
+
+  /**
+   * Filter by default severities
+   */
+  withSeverities(severities: RuleSeverity[]): this {
+    return this.setParam('severities', severities);
+  }
+
+  /**
+   * Filter by SonarSource security categories
+   */
+  withSonarSourceSecurity(categories: string[]): this {
+    return this.setParam('sonarsourceSecurity', categories);
+  }
+
+  /**
+   * Filter by rule statuses
+   */
+  withStatuses(statuses: RuleStatus[]): this {
+    return this.setParam('statuses', statuses);
+  }
+
+  /**
+   * Filter by tags
+   */
+  withTags(tags: string[]): this {
+    return this.setParam('tags', tags);
+  }
+
+  /**
+   * Filter by template rule key
+   */
+  withTemplateKey(key: string): this {
+    return this.setParam('template_key', key);
+  }
+
+  /**
+   * Filter by rule types
+   */
+  withTypes(types: RuleType[]): this {
+    return this.setParam('types', types);
+  }
+
+  /**
+   * Execute the search and return a single page
+   */
+  async execute(): Promise<SearchRulesResponse> {
+    return this.executor(this.params as SearchRulesRequest);
+  }
+
+  /**
+   * Get items from response for pagination
+   */
+  protected getItems(response: SearchRulesResponse): Rule[] {
+    return response.rules;
+  }
+}

--- a/src/resources/rules/index.ts
+++ b/src/resources/rules/index.ts
@@ -1,0 +1,3 @@
+export { RulesClient } from './RulesClient';
+export { SearchRulesBuilder } from './builders';
+export type * from './types';

--- a/src/resources/rules/types.ts
+++ b/src/resources/rules/types.ts
@@ -1,0 +1,436 @@
+/**
+ * Types for SonarQube Rules API
+ */
+
+/**
+ * Rule severity levels
+ */
+export type RuleSeverity = 'INFO' | 'MINOR' | 'MAJOR' | 'CRITICAL' | 'BLOCKER';
+
+/**
+ * Rule status
+ */
+export type RuleStatus = 'BETA' | 'DEPRECATED' | 'READY' | 'REMOVED';
+
+/**
+ * Rule type
+ */
+export type RuleType = 'CODE_SMELL' | 'BUG' | 'VULNERABILITY' | 'SECURITY_HOTSPOT';
+
+/**
+ * Clean Code attribute category
+ */
+export type CleanCodeAttributeCategory = 'ADAPTABLE' | 'CONSISTENT' | 'INTENTIONAL' | 'RESPONSIBLE';
+
+/**
+ * Software quality
+ */
+export type SoftwareQuality = 'MAINTAINABILITY' | 'RELIABILITY' | 'SECURITY';
+
+/**
+ * Impact severity
+ */
+export type ImpactSeverity = 'INFO' | 'LOW' | 'MEDIUM' | 'HIGH' | 'BLOCKER';
+
+/**
+ * Inheritance type for rule activation
+ */
+export type RuleInheritance = 'NONE' | 'INHERITED' | 'OVERRIDES';
+
+/**
+ * Remediation function type
+ */
+export type RemediationFunctionType = 'LINEAR' | 'LINEAR_OFFSET' | 'CONSTANT_ISSUE';
+
+/**
+ * Facet mode
+ */
+export type FacetMode = 'COUNT' | 'EFFORT' | 'DEBT';
+
+/**
+ * Rule repository
+ */
+export interface RuleRepository {
+  key: string;
+  name: string;
+  language: string;
+}
+
+/**
+ * Request parameters for listing rule repositories
+ */
+export interface ListRepositoriesRequest {
+  /**
+   * A language key; if provided, only repositories for the given language will be returned
+   */
+  language?: string;
+  /**
+   * A pattern to match repository keys/names against
+   */
+  q?: string;
+}
+
+/**
+ * Response for listing rule repositories
+ */
+export interface ListRepositoriesResponse {
+  repositories: RuleRepository[];
+}
+
+/**
+ * Rule parameter definition
+ */
+export interface RuleParameter {
+  key: string;
+  htmlDesc?: string;
+  defaultValue?: string;
+  type?: string;
+}
+
+/**
+ * Rule description section
+ */
+export interface RuleDescriptionSection {
+  key: string;
+  content: string;
+  context?: {
+    displayName?: string;
+    key?: string;
+  };
+}
+
+/**
+ * Rule impact
+ */
+export interface RuleImpact {
+  softwareQuality: SoftwareQuality;
+  severity: ImpactSeverity;
+}
+
+/**
+ * Rule activation details
+ */
+export interface RuleActivation {
+  qProfile: string;
+  inherit: RuleInheritance;
+  severity: RuleSeverity;
+  params?: Array<{
+    key: string;
+    value: string;
+  }>;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/**
+ * Rule details
+ */
+export interface Rule {
+  key: string;
+  repo: string;
+  name: string;
+  htmlDesc?: string; // Deprecated, use descriptionSections
+  mdDesc?: string;
+  descriptionSections?: RuleDescriptionSection[];
+  severity: RuleSeverity;
+  status: RuleStatus;
+  type: RuleType;
+  internalKey?: string;
+  isTemplate?: boolean;
+  isExternal?: boolean;
+  templateKey?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  tags?: string[];
+  sysTags?: string[];
+  lang?: string;
+  langName?: string;
+  params?: RuleParameter[];
+  remFn?: RemediationFunctionType;
+  remFnBaseEffort?: string;
+  remFnGapMultiplier?: string;
+  remFnOverloaded?: boolean;
+  defaultRemFn?: RemediationFunctionType;
+  defaultRemFnBaseEffort?: string;
+  defaultRemFnGapMultiplier?: string;
+  gapDescription?: string;
+  scope?: string;
+  securityStandards?: string[];
+  deprecatedKeys?: string[];
+  educationPrinciples?: string[];
+  noteLogin?: string;
+  htmlNote?: string;
+  mdNote?: string;
+  cleanCodeAttribute?: string;
+  cleanCodeAttributeCategory?: CleanCodeAttributeCategory;
+  impacts?: RuleImpact[];
+  actives?: RuleActivation[];
+}
+
+/**
+ * Request parameters for searching rules
+ */
+/* eslint-disable @typescript-eslint/naming-convention */
+export interface SearchRulesRequest {
+  /**
+   * Filter rules that are activated or deactivated on the selected Quality profile
+   */
+  activation?: boolean;
+  /**
+   * Comma-separated list of activation severities
+   */
+  active_severities?: RuleSeverity[];
+  /**
+   * Ascending sort
+   */
+  asc?: boolean;
+  /**
+   * Filters rules added since date. Format is yyyy-MM-dd
+   */
+  available_since?: string;
+  /**
+   * Comma-separated list of Clean Code Attribute Categories
+   */
+  cleanCodeAttributeCategories?: CleanCodeAttributeCategory[];
+  /**
+   * Comma-separated list of CWE identifiers
+   */
+  cwe?: string[];
+  /**
+   * Comma-separated list of the fields to be returned in response
+   */
+  f?: string[];
+  /**
+   * Comma-separated list of the facets to be computed
+   */
+  facets?: string[];
+  /**
+   * Comma-separated list of Software Quality Severities
+   */
+  impactSeverities?: ImpactSeverity[];
+  /**
+   * Comma-separated list of Software Qualities
+   */
+  impactSoftwareQualities?: SoftwareQuality[];
+  /**
+   * Include external engine rules in the results
+   */
+  include_external?: boolean;
+  /**
+   * Comma-separated list of values of inheritance for a rule within a quality profile
+   */
+  inheritance?: RuleInheritance[];
+  /**
+   * Filter template rules
+   */
+  is_template?: boolean;
+  /**
+   * Comma-separated list of languages
+   */
+  languages?: string[];
+  /**
+   * Organization key
+   */
+  organization?: string;
+  /**
+   * Comma-separated list of OWASP Top 10 lowercase categories
+   */
+  owaspTop10?: string[];
+  /**
+   * Comma-separated list of OWASP Top 10 (2021) lowercase categories
+   */
+  'owaspTop10-2021'?: string[];
+  /**
+   * 1-based page number
+   */
+  p?: number;
+  /**
+   * Page size. Must be greater than 0 and less or equal than 500
+   */
+  ps?: number;
+  /**
+   * UTF-8 search query
+   */
+  q?: string;
+  /**
+   * Quality profile key to filter on
+   */
+  qprofile?: string;
+  /**
+   * Comma-separated list of repositories
+   */
+  repositories?: string[];
+  /**
+   * Key of rule to search for
+   */
+  rule_key?: string;
+  /**
+   * Comma-separated list of rule keys
+   */
+  rule_keys?: string[];
+  /**
+   * Sort field
+   */
+  s?: 'name' | 'updatedAt' | 'createdAt' | 'key';
+  /**
+   * Comma-separated list of default severities
+   */
+  severities?: RuleSeverity[];
+  /**
+   * Comma-separated list of SonarSource security categories
+   */
+  sonarsourceSecurity?: string[];
+  /**
+   * Comma-separated list of status codes
+   */
+  statuses?: RuleStatus[];
+  /**
+   * Comma-separated list of tags
+   */
+  tags?: string[];
+  /**
+   * Key of the template rule to filter on
+   */
+  template_key?: string;
+  /**
+   * Comma-separated list of types
+   */
+  types?: RuleType[];
+}
+/* eslint-enable @typescript-eslint/naming-convention */
+
+/**
+ * Response for searching rules
+ */
+export interface SearchRulesResponse {
+  total: number;
+  p: number;
+  ps: number;
+  rules: Rule[];
+  facets?: Array<{
+    property: string;
+    values: Array<{
+      val: string;
+      count: number;
+    }>;
+  }>;
+  paging?: {
+    pageIndex: number;
+    pageSize: number;
+    total: number;
+  };
+}
+
+/**
+ * Request parameters for showing rule details
+ */
+export interface ShowRuleRequest {
+  /**
+   * Rule key
+   */
+  key: string;
+  /**
+   * Organization key
+   */
+  organization: string;
+  /**
+   * Show rule's activations for all profiles
+   */
+  actives?: boolean;
+}
+
+/**
+ * Response for showing rule details
+ */
+export interface ShowRuleResponse {
+  rule: Rule;
+  actives?: RuleActivation[];
+}
+
+/**
+ * Request parameters for listing rule tags
+ */
+export interface ListTagsRequest {
+  /**
+   * Organization key
+   */
+  organization: string;
+  /**
+   * Page size. Must be greater than 0 and less or equal than 100
+   */
+  ps?: number;
+  /**
+   * Limit search to tags that contain the supplied string
+   */
+  q?: string;
+}
+
+/**
+ * Response for listing rule tags
+ */
+export interface ListTagsResponse {
+  tags: string[];
+}
+
+/**
+ * Request parameters for updating a rule
+ */
+/* eslint-disable @typescript-eslint/naming-convention */
+export interface UpdateRuleRequest {
+  /**
+   * Key of the rule to update
+   */
+  key: string;
+  /**
+   * Organization key
+   */
+  organization: string;
+  /**
+   * Rule description (mandatory for custom rule and manual rule)
+   */
+  markdown_description?: string;
+  /**
+   * Optional note in markdown format
+   */
+  markdown_note?: string;
+  /**
+   * Rule name (mandatory for custom rule)
+   */
+  name?: string;
+  /**
+   * Parameters as semi-colon list of <key>=<value>
+   */
+  params?: string;
+  /**
+   * Base effort of the remediation function of the rule
+   */
+  remediation_fn_base_effort?: string;
+  /**
+   * Type of the remediation function of the rule
+   */
+  remediation_fn_type?: RemediationFunctionType;
+  /**
+   * Gap multiplier of the remediation function of the rule
+   */
+  remediation_fy_gap_multiplier?: string;
+  /**
+   * Rule severity (Only when updating a custom rule)
+   */
+  severity?: RuleSeverity;
+  /**
+   * Rule status (Only when updating a custom rule)
+   */
+  status?: RuleStatus;
+  /**
+   * Optional comma-separated list of tags to set
+   */
+  tags?: string;
+}
+/* eslint-enable @typescript-eslint/naming-convention */
+
+/**
+ * Response for updating a rule
+ */
+export interface UpdateRuleResponse {
+  rule: Rule;
+}


### PR DESCRIPTION
## Summary
- Implements comprehensive support for the SonarQube Rules API (`api/rules`)
- Adds TypeScript types, client methods, and builder patterns for all rules endpoints
- Follows established architectural patterns (ADR-002, ADR-003, ADR-006)

## Test plan
- [x] Unit tests for RulesClient covering all endpoints
- [x] Unit tests for SearchRulesBuilder with pagination support
- [x] MSW handlers for all rules endpoints
- [x] TypeScript type checking passes
- [x] ESLint checks pass
- [x] Integration with main SonarQubeClient

🤖 Generated with [Claude Code](https://claude.ai/code)