### PR TITLE
feat: Add support for SonarQube Users API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { ProjectTagsClient } from './resources/project-tags';
 import { QualityProfilesClient } from './resources/quality-profiles';
 import { RulesClient } from './resources/rules';
 import { SettingsClient } from './resources/settings';
+import { UsersClient } from './resources/users';
 
 interface ProjectsResponse {
   [key: string]: unknown;
@@ -99,6 +100,8 @@ export class SonarQubeClient {
   public readonly projectTags: ProjectTagsClient;
   /** Settings API */
   public readonly settings: SettingsClient;
+  /** Users API */
+  public readonly users: UsersClient;
 
   private readonly baseUrl: string;
   private readonly token: string;
@@ -142,6 +145,7 @@ export class SonarQubeClient {
     this.system = new SystemClient(this.baseUrl, this.token, this.organization);
     this.projectTags = new ProjectTagsClient(this.baseUrl, this.token, this.organization);
     this.settings = new SettingsClient(this.baseUrl, this.token, this.organization);
+    this.users = new UsersClient(this.baseUrl, this.token, this.organization);
   }
 
   // Legacy methods for backward compatibility
@@ -664,6 +668,18 @@ export type {
   SettingField,
   SettingValue,
 } from './resources/settings/types';
+
+// Re-export types from users
+export type {
+  User,
+  UserWithDetails,
+  UserGroup,
+  GroupSelectionFilter,
+  SearchUsersRequest,
+  SearchUsersResponse,
+  GetUserGroupsRequest,
+  GetUserGroupsResponse,
+} from './resources/users/types';
 
 // Re-export error classes
 export {

--- a/src/resources/users/UsersClient.ts
+++ b/src/resources/users/UsersClient.ts
@@ -1,0 +1,159 @@
+import { BaseClient } from '../../core/BaseClient';
+import { SearchUsersBuilder, GetUserGroupsBuilder } from './builders';
+import type {
+  UserWithDetails,
+  SearchUsersResponse,
+  GetUserGroupsResponse,
+  UserGroup,
+} from './types';
+
+/**
+ * Client for interacting with the SonarQube Users API.
+ * Provides methods for searching users and managing user groups.
+ */
+export class UsersClient extends BaseClient {
+  /**
+   * Get a list of active users from organizations the user making the request belongs to.
+   *
+   * @since 2.10
+   * @deprecated Since 10.8 (February 10, 2025). Use GET api/v2/users/search instead. Will be dropped August 13th 2025.
+   * @returns A builder for constructing the search request
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {RateLimitError} If the rate limit is exceeded
+   *
+   * @example
+   * ```typescript
+   * // Search for users by query
+   * const results = await client.users.search()
+   *   .query('john')
+   *   .pageSize(50)
+   *   .execute();
+   *
+   * // Search by IDs
+   * const users = await client.users.search()
+   *   .ids(['uuid-1', 'uuid-2'])
+   *   .execute();
+   *
+   * // Iterate through all users
+   * for await (const user of client.users.searchAll()) {
+   *   console.log(user.name);
+   * }
+   * ```
+   */
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  search(): SearchUsersBuilder {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    return new SearchUsersBuilder(async (params) => {
+      const query = new URLSearchParams();
+      if (params.ids !== undefined) {
+        query.append('ids', params.ids.join(','));
+      }
+      if (params.p !== undefined) {
+        query.append('p', String(params.p));
+      }
+      if (params.ps !== undefined) {
+        query.append('ps', String(params.ps));
+      }
+      if (params.q !== undefined) {
+        query.append('q', params.q);
+      }
+      const queryString = query.toString();
+      const url = queryString ? `/api/users/search?${queryString}` : '/api/users/search';
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      return this.request<SearchUsersResponse>(url);
+    });
+  }
+
+  /**
+   * Convenience method to iterate through all users.
+   * This is equivalent to calling search().all()
+   *
+   * @deprecated Since 10.8 (February 10, 2025). Use GET api/v2/users/search instead. Will be dropped August 13th 2025.
+   * @returns An async iterator for all users
+   *
+   * @example
+   * ```typescript
+   * for await (const user of client.users.searchAll()) {
+   *   console.log(user.name);
+   * }
+   * ```
+   */
+  searchAll(): AsyncIterableIterator<UserWithDetails> {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    return this.search().all();
+  }
+
+  /**
+   * Lists the groups a user belongs to.
+   *
+   * @since 5.2
+   * @returns A builder for constructing the groups request
+   * @throws {AuthenticationError} If the user is not authenticated
+   * @throws {AuthorizationError} If the user doesn't have 'Administer' permission on the organization
+   * @throws {NotFoundError} If the user or organization doesn't exist
+   *
+   * @example
+   * ```typescript
+   * // Get groups for a specific user
+   * const results = await client.users.groups()
+   *   .login('john.doe')
+   *   .organization('my-org')
+   *   .execute();
+   *
+   * // Search for specific groups
+   * const groups = await client.users.groups()
+   *   .login('john.doe')
+   *   .organization('my-org')
+   *   .query('admin')
+   *   .selected('all')
+   *   .execute();
+   *
+   * // Iterate through all groups
+   * for await (const group of client.users.groups()
+   *   .login('john.doe')
+   *   .organization('my-org')
+   *   .all()) {
+   *   console.log(group.name);
+   * }
+   * ```
+   */
+  groups(): GetUserGroupsBuilder {
+    return new GetUserGroupsBuilder(async (params) => {
+      const query = new URLSearchParams({
+        login: params.login,
+        organization: params.organization,
+      });
+      if (params.p !== undefined) {
+        query.append('p', String(params.p));
+      }
+      if (params.ps !== undefined) {
+        query.append('ps', String(params.ps));
+      }
+      if (params.q !== undefined) {
+        query.append('q', params.q);
+      }
+      if (params.selected !== undefined) {
+        query.append('selected', params.selected);
+      }
+      return this.request<GetUserGroupsResponse>(`/api/users/groups?${query.toString()}`);
+    });
+  }
+
+  /**
+   * Convenience method to iterate through all groups for a user.
+   *
+   * @param login - The user login
+   * @param organization - The organization key
+   * @returns An async iterator for all groups
+   *
+   * @example
+   * ```typescript
+   * for await (const group of client.users.groupsAll('john.doe', 'my-org')) {
+   *   console.log(group.name);
+   * }
+   * ```
+   */
+  groupsAll(login: string, organization: string): AsyncIterableIterator<UserGroup> {
+    return this.groups().login(login).organization(organization).all();
+  }
+}

--- a/src/resources/users/__tests__/UsersClient.test.ts
+++ b/src/resources/users/__tests__/UsersClient.test.ts
@@ -1,0 +1,483 @@
+/* eslint-disable @typescript-eslint/no-deprecated, @typescript-eslint/no-unused-vars */
+import { UsersClient } from '../UsersClient';
+import { SearchUsersBuilder, GetUserGroupsBuilder } from '../builders';
+import { server } from '../../../test-utils/msw/server';
+import { http, HttpResponse } from 'msw';
+// import { ValidationError } from '../../../errors';
+
+const mockBaseUrl = 'https://sonarqube.example.com';
+const mockToken = 'test-token';
+const mockOrganization = 'test-org';
+
+describe('UsersClient', () => {
+  let client: UsersClient;
+
+  beforeEach(() => {
+    client = new UsersClient(mockBaseUrl, mockToken, mockOrganization);
+  });
+
+  describe('search', () => {
+    it('should return a SearchUsersBuilder instance', () => {
+      const builder = client.search();
+      expect(builder).toBeInstanceOf(SearchUsersBuilder);
+    });
+
+    it('should execute search with query parameter', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/search`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get('q')).toBe('john');
+          return HttpResponse.json({
+            users: [
+              {
+                login: 'john.doe',
+                name: 'John Doe',
+                active: true,
+                avatar: 'avatar-hash',
+              },
+            ],
+            paging: {
+              pageIndex: 1,
+              pageSize: 50,
+              total: 1,
+            },
+          });
+        })
+      );
+
+      const result = await client.search().query('john').execute();
+      expect(result.users).toHaveLength(1);
+      expect(result.users[0].login).toBe('john.doe');
+      expect(result.users[0].name).toBe('John Doe');
+      expect(result.users[0].active).toBe(true);
+    });
+
+    it('should execute search with IDs parameter', async () => {
+      const testIds = ['uuid-1', 'uuid-2'];
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/search`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get('ids')).toBe('uuid-1,uuid-2');
+          return HttpResponse.json({
+            users: [
+              { login: 'user1', name: 'User 1', active: true },
+              { login: 'user2', name: 'User 2', active: true },
+            ],
+            paging: { pageIndex: 1, pageSize: 50, total: 2 },
+          });
+        })
+      );
+
+      const result = await client.search().ids(testIds).execute();
+      expect(result.users).toHaveLength(2);
+    });
+
+    it('should execute search with pagination parameters', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/search`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get('p')).toBe('2');
+          expect(url.searchParams.get('ps')).toBe('25');
+          return HttpResponse.json({
+            users: [],
+            paging: { pageIndex: 2, pageSize: 25, total: 0 },
+          });
+        })
+      );
+
+      const result = await client.search().page(2).pageSize(25).execute();
+      expect(result.paging.pageIndex).toBe(2);
+      expect(result.paging.pageSize).toBe(25);
+    });
+
+    it('should execute search without parameters', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/search`, ({ request }) => {
+          const url = new URL(request.url);
+          // Should not have any meaningful query parameters (q, ids, p, ps)
+          expect(url.searchParams.get('q')).toBeNull();
+          expect(url.searchParams.get('ids')).toBeNull();
+          expect(url.searchParams.get('p')).toBeNull();
+          expect(url.searchParams.get('ps')).toBeNull();
+          return HttpResponse.json({
+            users: [{ login: 'default', name: 'Default User', active: true }],
+            paging: { pageIndex: 1, pageSize: 50, total: 1 },
+          });
+        })
+      );
+
+      const result = await client.search().execute();
+      expect(result.users).toHaveLength(1);
+    });
+
+    it('should handle search with detailed user information', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/search`, ({ request }) => {
+          return HttpResponse.json({
+            users: [
+              {
+                login: 'admin',
+                name: 'Administrator',
+                active: true,
+                avatar: 'admin-avatar',
+                email: 'admin@example.com',
+                externalIdentity: 'external-id',
+                externalProvider: 'LDAP',
+                groups: ['administrators', 'developers'],
+                lastConnectionDate: '2024-01-01T12:00:00Z',
+                tokensCount: 3,
+              },
+            ],
+            paging: { pageIndex: 1, pageSize: 50, total: 1 },
+          });
+        })
+      );
+
+      const result = await client.search().execute();
+      const user = result.users[0];
+      expect(user.email).toBe('admin@example.com');
+      expect(user.externalIdentity).toBe('external-id');
+      expect(user.externalProvider).toBe('LDAP');
+      expect(user.groups).toEqual(['administrators', 'developers']);
+      expect(user.lastConnectionDate).toBe('2024-01-01T12:00:00Z');
+      expect(user.tokensCount).toBe(3);
+    });
+
+    it('should handle authentication errors', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/search`, ({ request }) => {
+          return HttpResponse.json(
+            { errors: [{ msg: 'Authentication required' }] },
+            { status: 401 }
+          );
+        })
+      );
+
+      await expect(client.search().execute()).rejects.toThrow();
+    });
+
+    it('should handle server errors', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/search`, ({ request }) => {
+          return HttpResponse.json({ errors: [{ msg: 'Internal server error' }] }, { status: 500 });
+        })
+      );
+
+      await expect(client.search().execute()).rejects.toThrow();
+    });
+  });
+
+  describe('searchAll', () => {
+    it('should return an async iterator for all users', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/search`, ({ request }) => {
+          const url = new URL(request.url);
+          const page = parseInt(url.searchParams.get('p') ?? '1');
+          if (page === 1) {
+            return HttpResponse.json({
+              users: [
+                { login: 'user1', name: 'User 1', active: true },
+                { login: 'user2', name: 'User 2', active: true },
+              ],
+              paging: { pageIndex: 1, pageSize: 2, total: 3 },
+            });
+          } else if (page === 2) {
+            return HttpResponse.json({
+              users: [{ login: 'user3', name: 'User 3', active: true }],
+              paging: { pageIndex: 2, pageSize: 2, total: 3 },
+            });
+          }
+          return HttpResponse.json({
+            users: [],
+            paging: { pageIndex: page, pageSize: 2, total: 3 },
+          });
+        })
+      );
+
+      const users = [];
+      for await (const user of client.searchAll()) {
+        users.push(user);
+      }
+
+      expect(users).toHaveLength(3);
+      expect(users[0].login).toBe('user1');
+      expect(users[1].login).toBe('user2');
+      expect(users[2].login).toBe('user3');
+    });
+
+    it('should handle empty results', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/search`, ({ request }) => {
+          return HttpResponse.json({
+            users: [],
+            paging: { pageIndex: 1, pageSize: 50, total: 0 },
+          });
+        })
+      );
+
+      const users = [];
+      for await (const user of client.searchAll()) {
+        users.push(user);
+      }
+
+      expect(users).toHaveLength(0);
+    });
+  });
+
+  describe('groups', () => {
+    it('should return a GetUserGroupsBuilder instance', () => {
+      const builder = client.groups();
+      expect(builder).toBeInstanceOf(GetUserGroupsBuilder);
+    });
+
+    it('should execute groups request with required parameters', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/groups`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get('login')).toBe('john.doe');
+          expect(url.searchParams.get('organization')).toBe('my-org');
+          return HttpResponse.json({
+            groups: [
+              {
+                name: 'developers',
+                description: 'Development team',
+                default: false,
+                selected: true,
+              },
+              {
+                name: 'users',
+                description: 'All users',
+                default: true,
+                selected: true,
+              },
+            ],
+            paging: { pageIndex: 1, pageSize: 25, total: 2 },
+          });
+        })
+      );
+
+      const result = await client.groups().login('john.doe').organization('my-org').execute();
+
+      expect(result.groups).toHaveLength(2);
+      expect(result.groups[0].name).toBe('developers');
+      expect(result.groups[0].description).toBe('Development team');
+      expect(result.groups[0].default).toBe(false);
+      expect(result.groups[0].selected).toBe(true);
+      expect(result.groups[1].default).toBe(true);
+    });
+
+    it('should execute groups request with query filter', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/groups`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get('q')).toBe('admin');
+          return HttpResponse.json({
+            groups: [
+              {
+                name: 'administrators',
+                description: 'System administrators',
+                default: false,
+                selected: false,
+              },
+            ],
+            paging: { pageIndex: 1, pageSize: 25, total: 1 },
+          });
+        })
+      );
+
+      const result = await client
+        .groups()
+        .login('john.doe')
+        .organization('my-org')
+        .query('admin')
+        .execute();
+
+      expect(result.groups).toHaveLength(1);
+      expect(result.groups[0].name).toBe('administrators');
+    });
+
+    it('should execute groups request with selection filter', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/groups`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get('selected')).toBe('all');
+          return HttpResponse.json({
+            groups: [
+              { name: 'group1', selected: true },
+              { name: 'group2', selected: false },
+            ],
+            paging: { pageIndex: 1, pageSize: 25, total: 2 },
+          });
+        })
+      );
+
+      const result = await client
+        .groups()
+        .login('john.doe')
+        .organization('my-org')
+        .selected('all')
+        .execute();
+
+      expect(result.groups).toHaveLength(2);
+      expect(result.groups[0].selected).toBe(true);
+      expect(result.groups[1].selected).toBe(false);
+    });
+
+    it('should execute groups request with pagination parameters', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/groups`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get('p')).toBe('2');
+          expect(url.searchParams.get('ps')).toBe('10');
+          return HttpResponse.json({
+            groups: [],
+            paging: { pageIndex: 2, pageSize: 10, total: 15 },
+          });
+        })
+      );
+
+      const result = await client
+        .groups()
+        .login('john.doe')
+        .organization('my-org')
+        .page(2)
+        .pageSize(10)
+        .execute();
+
+      expect(result.paging.pageIndex).toBe(2);
+      expect(result.paging.pageSize).toBe(10);
+    });
+
+    it('should handle groups with minimal information', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/groups`, ({ request }) => {
+          return HttpResponse.json({
+            groups: [
+              { name: 'simple-group' }, // Minimal group info
+            ],
+            paging: { pageIndex: 1, pageSize: 25, total: 1 },
+          });
+        })
+      );
+
+      const result = await client.groups().login('john.doe').organization('my-org').execute();
+
+      expect(result.groups).toHaveLength(1);
+      expect(result.groups[0].name).toBe('simple-group');
+      expect(result.groups[0].description).toBeUndefined();
+      expect(result.groups[0].default).toBeUndefined();
+      expect(result.groups[0].selected).toBeUndefined();
+    });
+
+    it('should handle authentication errors', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/groups`, ({ request }) => {
+          return HttpResponse.json(
+            { errors: [{ msg: 'Authentication required' }] },
+            { status: 401 }
+          );
+        })
+      );
+
+      await expect(
+        client.groups().login('john.doe').organization('my-org').execute()
+      ).rejects.toThrow();
+    });
+
+    it('should handle authorization errors', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/groups`, ({ request }) => {
+          return HttpResponse.json(
+            { errors: [{ msg: 'Insufficient permissions' }] },
+            { status: 403 }
+          );
+        })
+      );
+
+      await expect(
+        client.groups().login('john.doe').organization('my-org').execute()
+      ).rejects.toThrow();
+    });
+
+    it('should handle not found errors', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/groups`, ({ request }) => {
+          return HttpResponse.json({ errors: [{ msg: 'User not found' }] }, { status: 404 });
+        })
+      );
+
+      await expect(
+        client.groups().login('nonexistent').organization('my-org').execute()
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('groupsAll', () => {
+    it('should return an async iterator for all groups', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/groups`, ({ request }) => {
+          const url = new URL(request.url);
+          const page = parseInt(url.searchParams.get('p') ?? '1');
+          if (page === 1) {
+            return HttpResponse.json({
+              groups: [
+                { name: 'group1', description: 'Group 1' },
+                { name: 'group2', description: 'Group 2' },
+              ],
+              paging: { pageIndex: 1, pageSize: 2, total: 3 },
+            });
+          } else if (page === 2) {
+            return HttpResponse.json({
+              groups: [{ name: 'group3', description: 'Group 3' }],
+              paging: { pageIndex: 2, pageSize: 2, total: 3 },
+            });
+          }
+          return HttpResponse.json({
+            groups: [],
+            paging: { pageIndex: page, pageSize: 2, total: 3 },
+          });
+        })
+      );
+
+      const groups = [];
+      for await (const group of client.groupsAll('john.doe', 'my-org')) {
+        groups.push(group);
+      }
+
+      expect(groups).toHaveLength(3);
+      expect(groups[0].name).toBe('group1');
+      expect(groups[1].name).toBe('group2');
+      expect(groups[2].name).toBe('group3');
+    });
+
+    it('should handle empty results', async () => {
+      server.use(
+        http.get(`${mockBaseUrl}/api/users/groups`, ({ request }) => {
+          return HttpResponse.json({
+            groups: [],
+            paging: { pageIndex: 1, pageSize: 25, total: 0 },
+          });
+        })
+      );
+
+      const groups = [];
+      for await (const group of client.groupsAll('john.doe', 'my-org')) {
+        groups.push(group);
+      }
+
+      expect(groups).toHaveLength(0);
+    });
+  });
+
+  describe('client initialization', () => {
+    it('should create client with organization parameter', () => {
+      const clientWithOrg = new UsersClient(mockBaseUrl, mockToken, mockOrganization);
+      expect(clientWithOrg).toBeInstanceOf(UsersClient);
+    });
+
+    it('should create client without organization parameter', () => {
+      const clientWithoutOrg = new UsersClient(mockBaseUrl, mockToken);
+      expect(clientWithoutOrg).toBeInstanceOf(UsersClient);
+    });
+  });
+});

--- a/src/resources/users/__tests__/builders.test.ts
+++ b/src/resources/users/__tests__/builders.test.ts
@@ -1,0 +1,464 @@
+/* eslint-disable @typescript-eslint/no-deprecated, @typescript-eslint/restrict-template-expressions */
+import { SearchUsersBuilder, GetUserGroupsBuilder } from '../builders';
+import { ValidationError } from '../../../errors';
+
+describe('Users Builders', () => {
+  describe('SearchUsersBuilder', () => {
+    let mockExecutor: jest.Mock;
+    let builder: SearchUsersBuilder;
+
+    beforeEach(() => {
+      mockExecutor = jest.fn();
+      builder = new SearchUsersBuilder(mockExecutor);
+    });
+
+    describe('fluent interface', () => {
+      it('should set IDs parameter', () => {
+        const testIds = ['uuid-1', 'uuid-2', 'uuid-3'];
+        const result = builder.ids(testIds);
+        expect(result).toBe(builder);
+        expect(builder['params'].ids).toEqual(testIds);
+      });
+
+      it('should set query parameter', () => {
+        const result = builder.query('john');
+        expect(result).toBe(builder);
+        expect(builder['params'].q).toBe('john');
+      });
+
+      it('should set pagination parameters', () => {
+        builder.page(2).pageSize(25);
+        expect(builder['params'].p).toBe(2);
+        expect(builder['params'].ps).toBe(25);
+      });
+
+      it('should support method chaining', () => {
+        const result = builder.ids(['uuid-1', 'uuid-2']).query('search-term').page(1).pageSize(50);
+
+        expect(result).toBe(builder);
+        expect(builder['params'].ids).toEqual(['uuid-1', 'uuid-2']);
+        expect(builder['params'].q).toBe('search-term');
+        expect(builder['params'].p).toBe(1);
+        expect(builder['params'].ps).toBe(50);
+      });
+    });
+
+    describe('execute', () => {
+      it('should execute with valid parameters', async () => {
+        const mockResponse = {
+          users: [{ login: 'test', name: 'Test User', active: true }],
+          paging: { pageIndex: 1, pageSize: 50, total: 1 },
+        };
+        mockExecutor.mockResolvedValue(mockResponse);
+
+        const result = await builder.query('test').execute();
+
+        expect(mockExecutor).toHaveBeenCalledWith({
+          q: 'test',
+        });
+        expect(result).toBe(mockResponse);
+      });
+
+      it('should execute with all parameters', async () => {
+        const mockResponse = {
+          users: [],
+          paging: { pageIndex: 2, pageSize: 25, total: 0 },
+        };
+        mockExecutor.mockResolvedValue(mockResponse);
+
+        await builder.ids(['uuid-1', 'uuid-2']).query('search').page(2).pageSize(25).execute();
+
+        expect(mockExecutor).toHaveBeenCalledWith({
+          ids: ['uuid-1', 'uuid-2'],
+          q: 'search',
+          p: 2,
+          ps: 25,
+        });
+      });
+
+      it('should validate IDs array length', async () => {
+        const tooManyIds = Array.from({ length: 31 }, (_, i) => `uuid-${i}`);
+        builder.ids(tooManyIds);
+
+        await expect(builder.execute()).rejects.toThrow(ValidationError);
+        await expect(builder.execute()).rejects.toThrow('Maximum 30 user IDs allowed');
+      });
+
+      it('should validate IDs string length', async () => {
+        // Create IDs that will exceed 1110 character limit when joined
+        const longIds = Array.from({ length: 30 }, () => 'a'.repeat(40)); // 30 * 40 + 29 commas = 1229 chars
+        builder.ids(longIds);
+
+        await expect(builder.execute()).rejects.toThrow(ValidationError);
+        await expect(builder.execute()).rejects.toThrow(
+          'IDs string exceeds maximum length of 1110 characters'
+        );
+      });
+
+      it('should allow maximum valid IDs', async () => {
+        // Create exactly 30 IDs that stay under 1110 character limit
+        const validIds = Array.from(
+          { length: 30 },
+          (_, i) => `uuid-${i.toString().padStart(2, '0')}`
+        );
+        builder.ids(validIds);
+        mockExecutor.mockResolvedValue({
+          users: [],
+          paging: { pageIndex: 1, pageSize: 50, total: 0 },
+        });
+
+        await expect(builder.execute()).resolves.toBeDefined();
+      });
+
+      it('should validate query minimum length', async () => {
+        builder.query('a'); // Single character
+
+        await expect(builder.execute()).rejects.toThrow(ValidationError);
+        await expect(builder.execute()).rejects.toThrow('Query must be at least 2 characters long');
+      });
+
+      it('should allow valid query length', async () => {
+        builder.query('ab'); // Two characters - minimum valid
+        mockExecutor.mockResolvedValue({
+          users: [],
+          paging: { pageIndex: 1, pageSize: 50, total: 0 },
+        });
+
+        await expect(builder.execute()).resolves.toBeDefined();
+      });
+
+      it('should execute without parameters', async () => {
+        mockExecutor.mockResolvedValue({
+          users: [],
+          paging: { pageIndex: 1, pageSize: 50, total: 0 },
+        });
+
+        await builder.execute();
+
+        expect(mockExecutor).toHaveBeenCalledWith({});
+      });
+    });
+
+    describe('pagination', () => {
+      it('should extract items from response', () => {
+        const mockResponse = {
+          users: [
+            { login: 'user1', name: 'User 1', active: true },
+            { login: 'user2', name: 'User 2', active: true },
+          ],
+          paging: { pageIndex: 1, pageSize: 50, total: 2 },
+        };
+
+        const items = builder['getItems'](mockResponse);
+        expect(items).toHaveLength(2);
+        expect(items[0].login).toBe('user1');
+        expect(items[1].login).toBe('user2');
+      });
+
+      it('should support async iteration', async () => {
+        const page1Response = {
+          users: [
+            { login: 'user1', name: 'User 1', active: true },
+            { login: 'user2', name: 'User 2', active: true },
+          ],
+          paging: { pageIndex: 1, pageSize: 2, total: 3 },
+        };
+
+        const page2Response = {
+          users: [{ login: 'user3', name: 'User 3', active: true }],
+          paging: { pageIndex: 2, pageSize: 2, total: 3 },
+        };
+
+        mockExecutor.mockResolvedValueOnce(page1Response).mockResolvedValueOnce(page2Response);
+
+        const users = [];
+        for await (const user of builder.all()) {
+          users.push(user);
+        }
+
+        expect(users).toHaveLength(3);
+        expect(users[0].login).toBe('user1');
+        expect(users[1].login).toBe('user2');
+        expect(users[2].login).toBe('user3');
+      });
+    });
+  });
+
+  describe('GetUserGroupsBuilder', () => {
+    let mockExecutor: jest.Mock;
+    let builder: GetUserGroupsBuilder;
+
+    beforeEach(() => {
+      mockExecutor = jest.fn();
+      builder = new GetUserGroupsBuilder(mockExecutor);
+    });
+
+    describe('fluent interface', () => {
+      it('should set login parameter', () => {
+        const result = builder.login('john.doe');
+        expect(result).toBe(builder);
+        expect(builder['params'].login).toBe('john.doe');
+      });
+
+      it('should set organization parameter', () => {
+        const result = builder.organization('my-org');
+        expect(result).toBe(builder);
+        expect(builder['params'].organization).toBe('my-org');
+      });
+
+      it('should set query parameter', () => {
+        const result = builder.query('admin');
+        expect(result).toBe(builder);
+        expect(builder['params'].q).toBe('admin');
+      });
+
+      it('should set selected parameter', () => {
+        const result = builder.selected('all');
+        expect(result).toBe(builder);
+        expect(builder['params'].selected).toBe('all');
+      });
+
+      it('should set selected to deselected', () => {
+        builder.selected('deselected');
+        expect(builder['params'].selected).toBe('deselected');
+      });
+
+      it('should set selected to selected', () => {
+        builder.selected('selected');
+        expect(builder['params'].selected).toBe('selected');
+      });
+
+      it('should set pagination parameters', () => {
+        builder.page(3).pageSize(10);
+        expect(builder['params'].p).toBe(3);
+        expect(builder['params'].ps).toBe(10);
+      });
+
+      it('should support method chaining', () => {
+        const result = builder
+          .login('john.doe')
+          .organization('my-org')
+          .query('dev')
+          .selected('all')
+          .page(1)
+          .pageSize(25);
+
+        expect(result).toBe(builder);
+        expect(builder['params'].login).toBe('john.doe');
+        expect(builder['params'].organization).toBe('my-org');
+        expect(builder['params'].q).toBe('dev');
+        expect(builder['params'].selected).toBe('all');
+        expect(builder['params'].p).toBe(1);
+        expect(builder['params'].ps).toBe(25);
+      });
+    });
+
+    describe('execute', () => {
+      it('should execute with required parameters', async () => {
+        const mockResponse = {
+          groups: [{ name: 'developers', description: 'Dev team' }],
+          paging: { pageIndex: 1, pageSize: 25, total: 1 },
+        };
+        mockExecutor.mockResolvedValue(mockResponse);
+
+        const result = await builder.login('john.doe').organization('my-org').execute();
+
+        expect(mockExecutor).toHaveBeenCalledWith({
+          login: 'john.doe',
+          organization: 'my-org',
+        });
+        expect(result).toBe(mockResponse);
+      });
+
+      it('should execute with all parameters', async () => {
+        const mockResponse = {
+          groups: [],
+          paging: { pageIndex: 2, pageSize: 10, total: 0 },
+        };
+        mockExecutor.mockResolvedValue(mockResponse);
+
+        await builder
+          .login('john.doe')
+          .organization('my-org')
+          .query('admin')
+          .selected('deselected')
+          .page(2)
+          .pageSize(10)
+          .execute();
+
+        expect(mockExecutor).toHaveBeenCalledWith({
+          login: 'john.doe',
+          organization: 'my-org',
+          q: 'admin',
+          selected: 'deselected',
+          p: 2,
+          ps: 10,
+        });
+      });
+
+      it('should throw ValidationError when login is missing', async () => {
+        builder.organization('my-org');
+
+        await expect(builder.execute()).rejects.toThrow(ValidationError);
+        await expect(builder.execute()).rejects.toThrow('login is required');
+      });
+
+      it('should throw ValidationError when login is empty', async () => {
+        builder.login('').organization('my-org');
+
+        await expect(builder.execute()).rejects.toThrow(ValidationError);
+        await expect(builder.execute()).rejects.toThrow('login is required');
+      });
+
+      it('should throw ValidationError when organization is missing', async () => {
+        builder.login('john.doe');
+
+        await expect(builder.execute()).rejects.toThrow(ValidationError);
+        await expect(builder.execute()).rejects.toThrow('organization is required');
+      });
+
+      it('should throw ValidationError when organization is empty', async () => {
+        builder.login('john.doe').organization('');
+
+        await expect(builder.execute()).rejects.toThrow(ValidationError);
+        await expect(builder.execute()).rejects.toThrow('organization is required');
+      });
+
+      it('should throw ValidationError when both required parameters are missing', async () => {
+        await expect(builder.execute()).rejects.toThrow(ValidationError);
+        // Should throw for the first missing parameter (login)
+        await expect(builder.execute()).rejects.toThrow('login is required');
+      });
+    });
+
+    describe('pagination', () => {
+      it('should extract items from response', () => {
+        const mockResponse = {
+          groups: [
+            { name: 'group1', description: 'Group 1' },
+            { name: 'group2', description: 'Group 2' },
+          ],
+          paging: { pageIndex: 1, pageSize: 25, total: 2 },
+        };
+
+        const items = builder['getItems'](mockResponse);
+        expect(items).toHaveLength(2);
+        expect(items[0].name).toBe('group1');
+        expect(items[1].name).toBe('group2');
+      });
+
+      it('should support async iteration', async () => {
+        const page1Response = {
+          groups: [
+            { name: 'group1', description: 'Group 1' },
+            { name: 'group2', description: 'Group 2' },
+          ],
+          paging: { pageIndex: 1, pageSize: 2, total: 3 },
+        };
+
+        const page2Response = {
+          groups: [{ name: 'group3', description: 'Group 3' }],
+          paging: { pageIndex: 2, pageSize: 2, total: 3 },
+        };
+
+        mockExecutor.mockResolvedValueOnce(page1Response).mockResolvedValueOnce(page2Response);
+
+        builder.login('john.doe').organization('my-org');
+
+        const groups = [];
+        for await (const group of builder.all()) {
+          groups.push(group);
+        }
+
+        expect(groups).toHaveLength(3);
+        expect(groups[0].name).toBe('group1');
+        expect(groups[1].name).toBe('group2');
+        expect(groups[2].name).toBe('group3');
+      });
+
+      it('should handle empty results in async iteration', async () => {
+        const emptyResponse = {
+          groups: [],
+          paging: { pageIndex: 1, pageSize: 25, total: 0 },
+        };
+
+        mockExecutor.mockResolvedValue(emptyResponse);
+        builder.login('john.doe').organization('my-org');
+
+        const groups = [];
+        for await (const group of builder.all()) {
+          groups.push(group);
+        }
+
+        expect(groups).toHaveLength(0);
+      });
+    });
+
+    describe('parameter validation edge cases', () => {
+      it('should handle whitespace-only login', async () => {
+        builder.login('   ').organization('my-org');
+
+        await expect(builder.execute()).rejects.toThrow(ValidationError);
+        await expect(builder.execute()).rejects.toThrow('login is required');
+      });
+
+      it('should handle whitespace-only organization', async () => {
+        builder.login('john.doe').organization('   ');
+
+        await expect(builder.execute()).rejects.toThrow(ValidationError);
+        await expect(builder.execute()).rejects.toThrow('organization is required');
+      });
+
+      it('should accept valid trimmed parameters', async () => {
+        mockExecutor.mockResolvedValue({
+          groups: [],
+          paging: { pageIndex: 1, pageSize: 25, total: 0 },
+        });
+
+        await builder.login('john.doe').organization('my-org').execute();
+
+        expect(mockExecutor).toHaveBeenCalledWith({
+          login: 'john.doe',
+          organization: 'my-org',
+        });
+      });
+    });
+
+    describe('complex parameter combinations', () => {
+      it('should handle query with special characters', async () => {
+        mockExecutor.mockResolvedValue({
+          groups: [],
+          paging: { pageIndex: 1, pageSize: 25, total: 0 },
+        });
+
+        await builder.login('john.doe').organization('my-org').query('admin@company.com').execute();
+
+        expect(mockExecutor).toHaveBeenCalledWith({
+          login: 'john.doe',
+          organization: 'my-org',
+          q: 'admin@company.com',
+        });
+      });
+
+      it('should handle all selection filter options', async () => {
+        mockExecutor.mockResolvedValue({
+          groups: [],
+          paging: { pageIndex: 1, pageSize: 25, total: 0 },
+        });
+
+        // Test each valid selection filter value
+        const filters: Array<'all' | 'deselected' | 'selected'> = ['all', 'deselected', 'selected'];
+
+        for (const filter of filters) {
+          await builder.login('john.doe').organization('my-org').selected(filter).execute();
+
+          expect(mockExecutor).toHaveBeenLastCalledWith({
+            login: 'john.doe',
+            organization: 'my-org',
+            selected: filter,
+          });
+        }
+      });
+    });
+  });
+});

--- a/src/resources/users/builders.ts
+++ b/src/resources/users/builders.ts
@@ -146,10 +146,10 @@ export class GetUserGroupsBuilder extends PaginatedBuilder<
     const finalParams = this.params as GetUserGroupsRequest;
 
     // Validate required parameters
-    if (!finalParams.login) {
+    if (!finalParams.login || finalParams.login.trim() === '') {
       throw new ValidationError('login is required');
     }
-    if (!finalParams.organization) {
+    if (!finalParams.organization || finalParams.organization.trim() === '') {
       throw new ValidationError('organization is required');
     }
 

--- a/src/resources/users/builders.ts
+++ b/src/resources/users/builders.ts
@@ -1,0 +1,162 @@
+import { PaginatedBuilder, ParameterHelpers } from '../../core/builders';
+import { ValidationError } from '../../errors';
+import type {
+  SearchUsersRequest,
+  SearchUsersResponse,
+  UserWithDetails,
+  GetUserGroupsRequest,
+  GetUserGroupsResponse,
+  UserGroup,
+  GroupSelectionFilter,
+} from './types';
+
+/**
+ * Builder for constructing paginated user search requests.
+ *
+ * @deprecated Since 10.8 (February 10, 2025). Use GET api/v2/users/search instead. Will be dropped August 13th 2025.
+ *
+ * @example
+ * ```typescript
+ * // Search with pagination
+ * const results = await client.users.search()
+ *   .query('john')
+ *   .pageSize(50)
+ *   .page(2)
+ *   .execute();
+ *
+ * // Search by IDs
+ * const users = await client.users.search()
+ *   .ids(['uuid-1', 'uuid-2'])
+ *   .execute();
+ *
+ * // Iterate through all users
+ * for await (const user of client.users.search().all()) {
+ *   console.log(user.name);
+ * }
+ * ```
+ */
+export class SearchUsersBuilder extends PaginatedBuilder<
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  SearchUsersRequest,
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  SearchUsersResponse,
+  UserWithDetails
+> {
+  /**
+   * Filter on a list of one or more (max 30) user identifiers (comma-separated UUID V4).
+   * Maximum length: 1110 characters
+   */
+  ids = ParameterHelpers.createArrayMethod<typeof this>('ids');
+
+  /**
+   * Filter on login, name and email.
+   * Minimum length: 2 characters
+   */
+  query = ParameterHelpers.createStringMethod<typeof this>('q');
+
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  async execute(): Promise<SearchUsersResponse> {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const finalParams = this.params as SearchUsersRequest;
+
+    // Validate ids
+    if (finalParams.ids !== undefined) {
+      if (finalParams.ids.length > 30) {
+        throw new ValidationError('Maximum 30 user IDs allowed');
+      }
+      const idsString = finalParams.ids.join(',');
+      if (idsString.length > 1110) {
+        throw new ValidationError('IDs string exceeds maximum length of 1110 characters');
+      }
+    }
+
+    // Validate query
+    if (finalParams.q !== undefined && finalParams.q.length < 2) {
+      throw new ValidationError('Query must be at least 2 characters long');
+    }
+
+    return this.executor(finalParams);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  protected getItems(response: SearchUsersResponse): UserWithDetails[] {
+    return response.users;
+  }
+}
+
+/**
+ * Builder for constructing paginated user groups requests.
+ *
+ * @example
+ * ```typescript
+ * // Get groups with pagination
+ * const results = await client.users.groups()
+ *   .login('john.doe')
+ *   .organization('my-org')
+ *   .pageSize(50)
+ *   .execute();
+ *
+ * // Search for specific groups
+ * const groups = await client.users.groups()
+ *   .login('john.doe')
+ *   .organization('my-org')
+ *   .query('admin')
+ *   .selected('all')
+ *   .execute();
+ *
+ * // Iterate through all groups
+ * for await (const group of client.users.groups()
+ *   .login('john.doe')
+ *   .organization('my-org')
+ *   .all()) {
+ *   console.log(group.name);
+ * }
+ * ```
+ */
+export class GetUserGroupsBuilder extends PaginatedBuilder<
+  GetUserGroupsRequest,
+  GetUserGroupsResponse,
+  UserGroup
+> {
+  /**
+   * A user login (required).
+   */
+  login = ParameterHelpers.createStringMethod<typeof this>('login');
+
+  /**
+   * Organization key (required).
+   */
+  organization = ParameterHelpers.createStringMethod<typeof this>('organization');
+
+  /**
+   * Limit search to group names that contain the supplied string.
+   */
+  query = ParameterHelpers.createStringMethod<typeof this>('q');
+
+  /**
+   * Filter by selection status.
+   * Default: 'selected'
+   */
+  selected(value: GroupSelectionFilter): this {
+    this.params.selected = value;
+    return this;
+  }
+
+  async execute(): Promise<GetUserGroupsResponse> {
+    const finalParams = this.params as GetUserGroupsRequest;
+
+    // Validate required parameters
+    if (!finalParams.login) {
+      throw new ValidationError('login is required');
+    }
+    if (!finalParams.organization) {
+      throw new ValidationError('organization is required');
+    }
+
+    return this.executor(finalParams);
+  }
+
+  protected getItems(response: GetUserGroupsResponse): UserGroup[] {
+    return response.groups;
+  }
+}

--- a/src/resources/users/index.ts
+++ b/src/resources/users/index.ts
@@ -1,0 +1,12 @@
+export { UsersClient } from './UsersClient';
+export { SearchUsersBuilder, GetUserGroupsBuilder } from './builders';
+export type {
+  User,
+  UserWithDetails,
+  UserGroup,
+  GroupSelectionFilter,
+  SearchUsersRequest,
+  SearchUsersResponse,
+  GetUserGroupsRequest,
+  GetUserGroupsResponse,
+} from './types';

--- a/src/resources/users/types.ts
+++ b/src/resources/users/types.ts
@@ -1,0 +1,90 @@
+/**
+ * Types for the SonarQube Users API
+ */
+
+/**
+ * Base user information
+ */
+export interface User {
+  login: string;
+  name: string;
+  avatar?: string;
+  active: boolean;
+}
+
+/**
+ * Extended user information available to authenticated users
+ */
+export interface UserWithDetails extends User {
+  email?: string;
+  externalIdentity?: string;
+  externalProvider?: string;
+  groups?: string[];
+  lastConnectionDate?: string;
+  tokensCount?: number;
+}
+
+/**
+ * User group information
+ */
+export interface UserGroup {
+  name: string;
+  description?: string;
+  default?: boolean;
+  selected?: boolean;
+}
+
+/**
+ * Selection filter for groups
+ */
+export type GroupSelectionFilter = 'all' | 'deselected' | 'selected';
+
+/**
+ * Request parameters for search
+ * @since 2.10
+ * @deprecated Since 10.8 (February 10, 2025). Use GET api/v2/users/search instead. Will be dropped August 13th 2025.
+ */
+export interface SearchUsersRequest {
+  ids?: string[];
+  p?: number;
+  ps?: number;
+  q?: string;
+}
+
+/**
+ * Response from search
+ * @deprecated Since 10.8 (February 10, 2025). Use GET api/v2/users/search instead. Will be dropped August 13th 2025.
+ */
+export interface SearchUsersResponse {
+  users: UserWithDetails[];
+  paging: {
+    pageIndex: number;
+    pageSize: number;
+    total: number;
+  };
+}
+
+/**
+ * Request parameters for groups
+ * @since 5.2
+ */
+export interface GetUserGroupsRequest {
+  login: string;
+  organization: string;
+  p?: number;
+  ps?: number;
+  q?: string;
+  selected?: GroupSelectionFilter;
+}
+
+/**
+ * Response from groups
+ */
+export interface GetUserGroupsResponse {
+  groups: UserGroup[];
+  paging: {
+    pageIndex: number;
+    pageSize: number;
+    total: number;
+  };
+}


### PR DESCRIPTION
## Summary
- Implements comprehensive support for the SonarQube Users API endpoints
- Adds type-safe user search and group management functionality
- Includes proper deprecation warnings for deprecated endpoints

## Features Added
- **User Search** - Search for users by login, name, email, or specific IDs with pagination support
- **User Groups** - List and filter groups that a user belongs to with organization support
- **Builder Pattern** - Fluent API for complex queries with method chaining
- **Async Iteration** - Built-in pagination support for large datasets
- **Type Safety** - Full TypeScript definitions for all endpoints and responses

## API Endpoints
- `GET api/users/search` (deprecated, will be removed Aug 13, 2025)
- `GET api/users/groups`

## Implementation Details
- Follows established architectural patterns and ADRs
- Comprehensive parameter validation with custom error types
- Proper deprecation warnings for the users/search endpoint
- Integration with existing SonarQubeClient alongside Rules and Settings APIs
- Updated README with usage examples and API status

## Test Plan
- [x] TypeScript compilation passes
- [x] ESLint checks pass with proper deprecation handling
- [x] Integration with existing codebase verified
- [x] README documentation updated
- [ ] Comprehensive unit tests (to be added in follow-up)

🤖 Generated with [Claude Code](https://claude.ai/code)