### PR TITLE
feat: Add support for deprecated user_properties API

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ We're continuously adding support for more SonarQube/SonarCloud APIs. Here's wha
 | **System** | `api/system` | ✅ Implemented | SonarQube only | System information and health |
 | **Time Machine** | `api/timemachine` | ❌ Not implemented | Both | Historical measures (deprecated) |
 | **User Groups** | `api/user_groups` | ✅ Implemented | Both | User group management |
-| **User Properties** | `api/user_properties` | ❌ Not implemented | SonarCloud only | User property management |
+| **User Properties** | `api/user_properties` | ⚠️ Deprecated | Removed in 6.3 | Use favorites and notifications APIs |
 | **User Tokens** | `api/user_tokens` | ✅ Implemented | Both | User token management |
 | **Users** | `api/users` | ✅ Implemented | Both | User management (search deprecated) |
 | **Webhooks** | `api/webhooks` | ✅ Implemented | Both | Webhook management |

--- a/src/__tests__/user-properties-integration.test.ts
+++ b/src/__tests__/user-properties-integration.test.ts
@@ -1,0 +1,75 @@
+/* eslint-disable @typescript-eslint/no-deprecated */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import { SonarQubeClient } from '../index';
+import { SonarQubeError } from '../errors';
+import { DeprecationManager } from '../core/deprecation';
+
+describe('User Properties Integration', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    DeprecationManager.clearWarnings();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('should have userProperties accessible on main client', () => {
+    const client = new SonarQubeClient('https://sonarqube.example.com', 'token');
+    expect(client.userProperties).toBeDefined();
+  });
+
+  it('should throw error when calling index() method', async () => {
+    const client = new SonarQubeClient('https://sonarqube.example.com', 'token');
+
+    await expect(client.userProperties.index()).rejects.toThrow(SonarQubeError);
+
+    try {
+      await client.userProperties.index();
+    } catch (error) {
+      expect(error).toBeInstanceOf(SonarQubeError);
+      const sonarError = error as SonarQubeError;
+      expect(sonarError.code).toBe('API_REMOVED');
+      expect(sonarError.statusCode).toBe(410);
+      expect(sonarError.message).toContain('removed in SonarQube 6.3');
+      expect(sonarError.message).toContain('favorites');
+      expect(sonarError.message).toContain('notifications');
+    }
+  });
+
+  it('should emit deprecation warning when accessing userProperties', () => {
+    // Configure to suppress main client warnings but not userProperties
+    const client = new SonarQubeClient('https://sonarqube.example.com', 'token', {
+      suppressDeprecationWarnings: false,
+    });
+
+    // Access the deprecated client
+    const _userProps = client.userProperties;
+
+    // Should have warned about the deprecated class
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    const warning = consoleWarnSpy.mock.calls[0][0];
+    expect(warning).toContain('UserPropertiesClient');
+    expect(warning).toContain('removed in SonarQube 6.3');
+  });
+
+  it('should guide users to alternatives', async () => {
+    const client = new SonarQubeClient('https://sonarqube.example.com', 'token');
+
+    try {
+      await client.userProperties.index();
+    } catch (error) {
+      const sonarError = error as SonarQubeError;
+      expect(sonarError.details).toMatchObject({
+        migration: {
+          favorites: expect.stringContaining('client.favorites'),
+          notifications: expect.stringContaining('client.notifications'),
+        },
+      });
+    }
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { SettingsClient } from './resources/settings';
 import { UsersClient } from './resources/users';
 import { UserGroupsClient } from './resources/user-groups';
 import { UserTokensClient } from './resources/user-tokens';
+import { UserPropertiesClient } from './resources/user-properties';
 import { PermissionsClient } from './resources/permissions';
 import { WebhooksClient } from './resources/webhooks';
 import { WebservicesClient } from './resources/webservices';
@@ -115,6 +116,12 @@ export class SonarQubeClient {
   public readonly userGroups: UserGroupsClient;
   /** User Tokens API */
   public readonly userTokens: UserTokensClient;
+  /**
+   * User Properties API - **Removed since SonarQube 6.3**
+   * @deprecated Use favorites and notifications APIs instead
+   */
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  public readonly userProperties: UserPropertiesClient;
   /** Webhooks API */
   public readonly webhooks: WebhooksClient;
   /** Webservices API - Get information on the web API supported on this instance */
@@ -175,6 +182,8 @@ export class SonarQubeClient {
     this.users = new UsersClient(this.baseUrl, this.token, this.options);
     this.userGroups = new UserGroupsClient(this.baseUrl, this.token, this.options);
     this.userTokens = new UserTokensClient(this.baseUrl, this.token, this.options);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    this.userProperties = new UserPropertiesClient(this.baseUrl, this.token, this.options);
     this.webhooks = new WebhooksClient(this.baseUrl, this.token, this.options);
     this.webservices = new WebservicesClient(this.baseUrl, this.token, this.options);
   }
@@ -776,6 +785,9 @@ export type {
   SearchTokensResponse,
   UserToken,
 } from './resources/user-tokens/types';
+
+// Re-export types from user properties (deprecated)
+export type { UserPropertiesResponse, UserProperty } from './resources/user-properties/types';
 
 // Re-export types from webhooks
 export type {

--- a/src/resources/user-properties/UserPropertiesClient.ts
+++ b/src/resources/user-properties/UserPropertiesClient.ts
@@ -1,0 +1,99 @@
+import { BaseClient } from '../../core/BaseClient';
+import { DeprecatedClass } from '../../core/deprecation';
+import { SonarQubeError } from '../../errors';
+import type { UserPropertiesResponse } from './types';
+
+/**
+ * Client for the deprecated User Properties API
+ *
+ * @deprecated The user_properties API was removed in SonarQube 6.3.
+ * Use the favorites and notifications APIs instead:
+ * - For favorites: Use `client.favorites`
+ * - For notifications: Use `client.notifications`
+ *
+ * @example Migration from user_properties to favorites:
+ * ```typescript
+ * // Before (user_properties):
+ * const properties = await client.userProperties.index();
+ *
+ * // After (favorites):
+ * const favorites = await client.favorites.search();
+ * ```
+ *
+ * @example Migration from user_properties to notifications:
+ * ```typescript
+ * // Before (user_properties):
+ * const properties = await client.userProperties.index();
+ *
+ * // After (notifications):
+ * const notifications = await client.notifications.list();
+ * ```
+ */
+@DeprecatedClass({
+  reason: 'The user_properties API was removed in SonarQube 6.3',
+  replacement: 'favorites and notifications APIs',
+  deprecatedSince: '6.3',
+  removalDate: '2017-06-05', // SonarQube 6.3 release date
+  migrationGuide: `The user_properties API has been split into two separate APIs:
+  
+1. **Favorites API** - For managing favorite projects/components:
+   - Use \`client.favorites.add()\` to add a favorite
+   - Use \`client.favorites.remove()\` to remove a favorite
+   - Use \`client.favorites.search()\` to list favorites
+
+2. **Notifications API** - For managing notification preferences:
+   - Use \`client.notifications.add()\` to add a notification
+   - Use \`client.notifications.remove()\` to remove a notification
+   - Use \`client.notifications.list()\` to list notifications
+
+Note: The old user_properties API combined both favorites and notifications into a single endpoint. 
+You now need to use the appropriate API based on your use case.`,
+  examples: [
+    {
+      before: `const properties = await client.userProperties.index();`,
+      after: `// For favorites:
+const favorites = await client.favorites.search();
+
+// For notifications:
+const notifications = await client.notifications.list();`,
+      description:
+        'Split your user_properties calls into favorites or notifications based on the property type',
+    },
+  ],
+})
+export class UserPropertiesClient extends BaseClient {
+  /**
+   * Get user properties (removed endpoint)
+   *
+   * @deprecated This endpoint was removed in SonarQube 6.3. Use favorites.search() or notifications.list() instead.
+   * @throws {SonarQubeError} Always throws an error indicating the API was removed
+   *
+   * @example
+   * ```typescript
+   * // This will throw an error:
+   * try {
+   *   await client.userProperties.index();
+   * } catch (error) {
+   *   // Error will guide you to use favorites or notifications APIs
+   * }
+   * ```
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await, @typescript-eslint/no-deprecated
+  async index(): Promise<UserPropertiesResponse> {
+    throw new SonarQubeError(
+      'The user_properties API was removed in SonarQube 6.3. ' +
+        'Please use the favorites API (client.favorites) for managing favorite projects, ' +
+        'or the notifications API (client.notifications) for managing notification preferences.',
+      'API_REMOVED',
+      410, // Gone status code
+      {
+        error: 'api_removed',
+        message: 'This API endpoint has been removed',
+        migration: {
+          favorites: 'Use client.favorites for managing favorite projects',
+          notifications: 'Use client.notifications for managing notification preferences',
+        },
+      }
+    );
+  }
+}

--- a/src/resources/user-properties/__tests__/UserPropertiesClient.test.ts
+++ b/src/resources/user-properties/__tests__/UserPropertiesClient.test.ts
@@ -1,0 +1,131 @@
+/* eslint-disable @typescript-eslint/no-deprecated */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import { UserPropertiesClient } from '../UserPropertiesClient';
+import { SonarQubeError } from '../../../errors';
+import { DeprecationManager } from '../../../core/deprecation';
+
+describe('UserPropertiesClient', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // Set up spies before creating client
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    // Clear deprecation warnings and reset configuration
+    DeprecationManager.clearWarnings();
+    DeprecationManager.configure({});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+  });
+
+  describe('constructor', () => {
+    it('should emit deprecation warning when instantiated', () => {
+      // Clear any previous warnings
+      DeprecationManager.clearWarnings();
+
+      new UserPropertiesClient('https://sonarqube.example.com', 'token', {});
+
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      const warning = consoleWarnSpy.mock.calls[0][0];
+      expect(warning).toContain('DEPRECATED API USAGE');
+      expect(warning).toContain('API: UserPropertiesClient');
+      expect(warning).toContain('Replacement: favorites and notifications APIs');
+    });
+
+    it('should include removal date in warning', () => {
+      DeprecationManager.clearWarnings();
+
+      new UserPropertiesClient('https://sonarqube.example.com', 'token', {});
+
+      const warning = consoleWarnSpy.mock.calls[0][0];
+      expect(warning).toContain('Will be removed in: 2017-06-05');
+    });
+
+    it('should include migration guide in warning', () => {
+      DeprecationManager.clearWarnings();
+
+      new UserPropertiesClient('https://sonarqube.example.com', 'token', {});
+
+      const warning = consoleWarnSpy.mock.calls[0][0];
+      expect(warning).toContain('Migration guide:');
+      expect(warning).toContain('Favorites API');
+      expect(warning).toContain('Notifications API');
+    });
+  });
+
+  describe('index', () => {
+    it('should always throw SonarQubeError with 410 status', async () => {
+      const client = new UserPropertiesClient('https://sonarqube.example.com', 'token', {});
+
+      await expect(client.index()).rejects.toThrow(SonarQubeError);
+
+      try {
+        await client.index();
+      } catch (error) {
+        expect(error).toBeInstanceOf(SonarQubeError);
+        expect((error as SonarQubeError).statusCode).toBe(410);
+        expect((error as SonarQubeError).message).toContain('removed in SonarQube 6.3');
+        expect((error as SonarQubeError).message).toContain('favorites API');
+        expect((error as SonarQubeError).message).toContain('notifications API');
+      }
+    });
+
+    it('should include migration information in error details', async () => {
+      const client = new UserPropertiesClient('https://sonarqube.example.com', 'token', {});
+
+      try {
+        await client.index();
+      } catch (error) {
+        const sonarError = error as SonarQubeError;
+        expect(sonarError.details).toEqual({
+          error: 'api_removed',
+          message: 'This API endpoint has been removed',
+          migration: {
+            favorites: 'Use client.favorites for managing favorite projects',
+            notifications: 'Use client.notifications for managing notification preferences',
+          },
+        });
+      }
+    });
+
+    it('should not make any HTTP requests', async () => {
+      const client = new UserPropertiesClient('https://sonarqube.example.com', 'token', {});
+      const fetchSpy = jest.spyOn(global, 'fetch');
+
+      try {
+        await client.index();
+      } catch {
+        // Expected to throw
+      }
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
+  });
+
+  describe('deprecation behavior', () => {
+    it('should respect deprecation configuration', () => {
+      // Test with warnings disabled
+      DeprecationManager.configure({ suppressDeprecationWarnings: true });
+      DeprecationManager.clearWarnings();
+
+      const _client = new UserPropertiesClient('https://sonarqube.example.com', 'token', {
+        suppressDeprecationWarnings: true,
+      });
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(consoleLogSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/resources/user-properties/index.ts
+++ b/src/resources/user-properties/index.ts
@@ -1,0 +1,8 @@
+/**
+ * User Properties API - Removed in SonarQube 6.3
+ * @deprecated Use favorites and notifications APIs instead
+ * @module
+ */
+
+export { UserPropertiesClient } from './UserPropertiesClient';
+export type { UserPropertiesResponse, UserProperty } from './types';

--- a/src/resources/user-properties/types.ts
+++ b/src/resources/user-properties/types.ts
@@ -1,0 +1,37 @@
+/**
+ * User Properties types
+ * @deprecated The user_properties API was removed in SonarQube 6.3. Use favorites and notifications APIs instead.
+ * @module
+ */
+
+/* eslint-disable @typescript-eslint/no-deprecated */
+
+/**
+ * Response from the deprecated user_properties/index endpoint
+ * @deprecated This API was removed in SonarQube 6.3
+ */
+export interface UserPropertiesResponse {
+  /**
+   * Array of user properties
+   * @deprecated Use favorites and notifications APIs instead
+   */
+  properties: UserProperty[];
+}
+
+/**
+ * A user property
+ * @deprecated This type is from a removed API
+ */
+export interface UserProperty {
+  /**
+   * Property key
+   * @deprecated Use favorites or notifications based on the property type
+   */
+  key: string;
+
+  /**
+   * Property value
+   * @deprecated Use favorites or notifications based on the property type
+   */
+  value: string;
+}


### PR DESCRIPTION
## Summary
- Implement UserPropertiesClient for the deprecated `api/user_properties` endpoint
- Add comprehensive deprecation handling that guides users to replacement APIs
- Include full test coverage and documentation updates

## Implementation Details

This PR adds support for the `api/user_properties` endpoint, which was removed in SonarQube 6.3. The implementation follows the project's architectural decisions:

### Following ADR-0002 (Modular Resource-Based Design)
- Created a dedicated `UserPropertiesClient` class in `/src/resources/user-properties/`
- Integrated with the main `SonarQubeClient` facade
- Follows the established pattern used by other resources

### Following ADR-0009 (Deprecation Management System)
- Uses `@DeprecatedClass` decorator with comprehensive metadata
- Provides clear migration guides to `favorites` and `notifications` APIs
- Throws informative errors (410 Gone) when methods are called
- Includes examples showing before/after migration code

### Key Features
1. **Helpful Error Messages**: When users try to use the removed API, they get clear guidance:
   ```
   The user_properties API was removed in SonarQube 6.3.
   Please use the favorites API (client.favorites) for managing favorite projects,
   or the notifications API (client.notifications) for managing notification preferences.
   ```

2. **Deprecation Warnings**: The client emits warnings when instantiated, showing:
   - The reason for deprecation
   - Removal date
   - Migration guide with examples
   - Links to replacement APIs

3. **Complete Test Coverage**: 
   - Unit tests for the client behavior
   - Integration tests verifying the client is accessible
   - Tests for deprecation warnings and error handling

4. **Documentation**: Updated README to show the API status as deprecated/removed

## Test plan
- [x] All existing tests pass
- [x] New unit tests for UserPropertiesClient
- [x] New integration tests
- [x] Linting and type checking pass
- [x] Code formatting is correct

🤖 Generated with [Claude Code](https://claude.ai/code)