### PR TITLE
fix: Replace regex-based hyphen removal with loop-based approach

### DIFF
--- a/src/resources/clean-code-policy/utils.ts
+++ b/src/resources/clean-code-policy/utils.ts
@@ -36,7 +36,14 @@ export const ruleKeyUtils = {
     let key = name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
 
     // Remove leading and trailing hyphens
-    key = key.replace(/^-+/, '').replace(/-+$/, '');
+    // Remove leading hyphens
+    while (key.startsWith('-')) {
+      key = key.slice(1);
+    }
+    // Remove trailing hyphens
+    while (key.endsWith('-')) {
+      key = key.slice(0, -1);
+    }
 
     // Add prefix if provided
     if (prefix !== undefined && prefix !== '') {


### PR DESCRIPTION
## Summary
- Replaced regex patterns for removing leading/trailing hyphens with while loops
- Eliminates potential ReDoS vulnerability flagged by SonarQube

## Details
SonarQube identified a security hotspot at line 39 where the regex `/-+$/` could cause super-linear runtime due to backtracking. Even though the regex was already split from the original `/(^-+)|(-+$)/g`, the unbounded repetition `-+` at the end of string can still be problematic.

### Solution
Replaced both regex patterns with while loops:
```typescript
// Before:
key = key.replace(/^-+/, '').replace(/-+$/, '');

// After:
while (key.startsWith('-')) {
  key = key.slice(1);
}
while (key.endsWith('-')) {
  key = key.slice(0, -1);
}
```

This approach:
- Has guaranteed linear time complexity O(n)
- Eliminates any regex backtracking concerns
- Is more readable and explicit about the intent
- Maintains the same functionality

## Test plan
- [x] All existing tests pass
- [x] Linting passes
- [x] Type checking passes
- [x] Coverage remains at required levels

🤖 Generated with [Claude Code](https://claude.ai/code)